### PR TITLE
Fix for Issue #70: stopPython() errors

### DIFF
--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -236,7 +236,6 @@ JNIEXPORT jboolean JNICALL Java_org_jpy_PyLib_startPython0
     }
     return JNI_TRUE;
 }
-  
 
 /*
  * Class:     org_jpy_PyLib
@@ -1174,6 +1173,3 @@ void PyLib_RedirectStdOut(void)
     PySys_SetObject("stdout", module);
     PySys_SetObject("stderr", module);
 }
-
-
-

--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -250,16 +250,10 @@ JNIEXPORT void JNICALL Java_org_jpy_PyLib_stopPython
     if (Py_IsInitialized()) {
         // Make sure we can get the GIL if needed before cleaning up.
         PyGILState_STATE state = PyGILState_Ensure();
+        // Cleanup the JPY stateful structures and shut the interpreter down.
         JPy_free();
-        //JPy_ClearGlobalVars(jenv);
         Py_Finalize();
-
-        // Clear out stateful pointers to JPY stuff and reset threads flag
-
-        //JPy_Module = NULL;
-        //JPy_Types = NULL;
-        //JPy_Type_Callbacks = NULL;
-        //JException_Type = NULL;
+        // Make sure we reset our global flag
         JPy_InitThreads = 0;
     }
 

--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -248,8 +248,19 @@ JNIEXPORT void JNICALL Java_org_jpy_PyLib_stopPython
     JPy_DIAG_PRINT(JPy_DIAG_F_ALL, "Java_org_jpy_PyLib_stopPython: entered: JPy_Module=%p\n", JPy_Module);
 
     if (Py_IsInitialized()) {
-        PyGILState_Ensure();
+        // Make sure we can get the GIL if needed before cleaning up.
+        PyGILState_STATE state = PyGILState_Ensure();
+        JPy_free();
+        //JPy_ClearGlobalVars(jenv);
         Py_Finalize();
+
+        // Clear out stateful pointers to JPY stuff and reset threads flag
+
+        //JPy_Module = NULL;
+        //JPy_Types = NULL;
+        //JPy_Type_Callbacks = NULL;
+        //JException_Type = NULL;
+        JPy_InitThreads = 0;
     }
 
     JPy_DIAG_PRINT(JPy_DIAG_F_ALL, "Java_org_jpy_PyLib_stopPython: exiting: JPy_Module=%p\n", JPy_Module);

--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -249,6 +249,7 @@ JNIEXPORT void JNICALL Java_org_jpy_PyLib_stopPython
     JPy_DIAG_PRINT(JPy_DIAG_F_ALL, "Java_org_jpy_PyLib_stopPython: entered: JPy_Module=%p\n", JPy_Module);
 
     if (Py_IsInitialized()) {
+        PyGILState_Ensure();
         Py_Finalize();
     }
 

--- a/src/main/java/org/jpy/PyProxyHandler.java
+++ b/src/main/java/org/jpy/PyProxyHandler.java
@@ -43,19 +43,15 @@ class PyProxyHandler implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxyObject, Method method, Object[] args) throws Throwable {
-        if(method.getName().equalsIgnoreCase("toString")) {
-            return String.valueOf(this.pyObject.toString());
-        }
-
         assertPythonRuns();
 
-        //if ((PyLib.Diag.getFlags() & PyLib.Diag.F_METH) != 0) {
+        if ((PyLib.Diag.getFlags() & PyLib.Diag.F_METH) != 0) {
             System.out.printf("org.jpy.PyProxyHandler: invoke: %s(%s) on pyObject=%s in thread %s\n",
                               method.getName(),
                               Arrays.toString(args),
                               Long.toHexString(this.pyObject.getPointer()),
                               Thread.currentThread());
-        //}
+        }
 
         return PyLib.callAndReturnValue(this.pyObject.getPointer(),
                                         callableKind == PyLib.CallableKind.METHOD,

--- a/src/main/java/org/jpy/PyProxyHandler.java
+++ b/src/main/java/org/jpy/PyProxyHandler.java
@@ -43,15 +43,19 @@ class PyProxyHandler implements InvocationHandler {
 
     @Override
     public Object invoke(Object proxyObject, Method method, Object[] args) throws Throwable {
+        if(method.getName().equalsIgnoreCase("toString")) {
+            return String.valueOf(this.pyObject.toString());
+        }
+
         assertPythonRuns();
 
-        if ((PyLib.Diag.getFlags() & PyLib.Diag.F_METH) != 0) {
+        //if ((PyLib.Diag.getFlags() & PyLib.Diag.F_METH) != 0) {
             System.out.printf("org.jpy.PyProxyHandler: invoke: %s(%s) on pyObject=%s in thread %s\n",
                               method.getName(),
                               Arrays.toString(args),
                               Long.toHexString(this.pyObject.getPointer()),
                               Thread.currentThread());
-        }
+        //}
 
         return PyLib.callAndReturnValue(this.pyObject.getPointer(),
                                         callableKind == PyLib.CallableKind.METHOD,

--- a/src/test/java/org/jpy/LifeCycleTest.java
+++ b/src/test/java/org/jpy/LifeCycleTest.java
@@ -11,12 +11,19 @@ public class LifeCycleTest {
   public void testCanStartAndStopWithoutException() {
     PyLib.startPython();
     Assert.assertTrue(PyLib.isPythonRunning());
+    PyModule sys = PyModule.importModule("sys");
+    Assert.assertNotNull(sys);
+    final long firstPointer = sys.getPointer();
 
     PyLib.stopPython();
     Assert.assertFalse(PyLib.isPythonRunning());
 
     PyLib.startPython();
     Assert.assertTrue(PyLib.isPythonRunning());
+
+    sys = PyModule.importModule("sys");
+    final long secondPointer = sys.getPointer();
+    Assert.assertNotEquals(firstPointer, secondPointer);
 
     PyLib.stopPython();
     Assert.assertFalse(PyLib.isPythonRunning());

--- a/src/test/java/org/jpy/LifeCycleTest.java
+++ b/src/test/java/org/jpy/LifeCycleTest.java
@@ -1,0 +1,25 @@
+package org.jpy;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class LifeCycleTest {
+
+  @Test
+  public void testCanStartAndStopWithoutException() {
+    PyLib.startPython();
+    Assert.assertTrue(PyLib.isPythonRunning());
+
+    PyLib.stopPython();
+    Assert.assertFalse(PyLib.isPythonRunning());
+
+    PyLib.startPython();
+    Assert.assertTrue(PyLib.isPythonRunning());
+
+    PyLib.stopPython();
+    Assert.assertFalse(PyLib.isPythonRunning());
+  }
+
+}

--- a/src/test/java/org/jpy/LifeCycleTest.java
+++ b/src/test/java/org/jpy/LifeCycleTest.java
@@ -1,8 +1,6 @@
 package org.jpy;
 
-import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class LifeCycleTest {

--- a/src/test/java/org/jpy/PyLibTest.java
+++ b/src/test/java/org/jpy/PyLibTest.java
@@ -33,7 +33,7 @@ public class PyLibTest {
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        //PyLib.stopPython();
+        PyLib.stopPython();
     }
 
     @Test

--- a/src/test/java/org/jpy/PyLibTest.java
+++ b/src/test/java/org/jpy/PyLibTest.java
@@ -16,23 +16,21 @@
 
 package org.jpy;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import static org.junit.Assert.*;
 
 public class PyLibTest {
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         //PyLib.Diag.setFlags(PyLib.Diag.F_ERR);
         PyLib.startPython();
         assertEquals(true, PyLib.isPythonRunning());
     }
 
-    @AfterClass
-    public static void tearDownClass() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         PyLib.stopPython();
     }
 

--- a/src/test/java/org/jpy/PyLibWithSysPathTest.java
+++ b/src/test/java/org/jpy/PyLibWithSysPathTest.java
@@ -16,9 +16,7 @@
 
 package org.jpy;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
 
 import java.io.File;
 import java.net.URI;
@@ -28,8 +26,8 @@ import static org.junit.Assert.*;
 
 public class PyLibWithSysPathTest {
 
-    @BeforeClass
-    public static void setUpClass() throws Exception {
+    @Before
+    public void setUp() throws Exception {
 
         CodeSource codeSource = PyLibWithSysPathTest.class.getProtectionDomain().getCodeSource();
         if (codeSource == null) {
@@ -52,8 +50,8 @@ public class PyLibWithSysPathTest {
         assertTrue(PyLib.isPythonRunning());
     }
 
-    @AfterClass
-    public static void tearDownClass() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         PyLib.stopPython();
     }
 

--- a/src/test/java/org/jpy/PyLibWithSysPathTest.java
+++ b/src/test/java/org/jpy/PyLibWithSysPathTest.java
@@ -54,7 +54,7 @@ public class PyLibWithSysPathTest {
 
     @AfterClass
     public static void tearDownClass() throws Exception {
-        //PyLib.stopPython();
+        PyLib.stopPython();
     }
 
     @Test

--- a/src/test/java/org/jpy/PyModuleTest.java
+++ b/src/test/java/org/jpy/PyModuleTest.java
@@ -54,12 +54,12 @@ public class PyModuleTest {
     }
 
     // see https://github.com/bcdev/jpy/issues/26
-    //@Test
-    //public void testCreateAndCallProxyMultiThreaded() throws Exception {
-    //    PyObjectTest.addTestDirToPythonSysPath();
-    //    PyModule procModule = PyModule.importModule("proc_module");
-    //    PyObjectTest.testCallProxyMultiThreaded(procModule);
-    //}
+    @Test
+    public void testCreateAndCallProxyMultiThreaded() throws Exception {
+        PyObjectTest.addTestDirToPythonSysPath();
+        PyModule procModule = PyModule.importModule("proc_module");
+        PyObjectTest.testCallProxyMultiThreaded(procModule);
+    }
 
     // see: https://github.com/bcdev/jpy/issues/39: Improve Java exception messages on Python errors #39
     @Test

--- a/src/test/java/org/jpy/PyModuleTest.java
+++ b/src/test/java/org/jpy/PyModuleTest.java
@@ -43,7 +43,7 @@ public class PyModuleTest {
     @AfterClass
     public static void tearDown() throws Exception {
         PyLib.Diag.setFlags(PyLib.Diag.F_OFF);
-        //PyLib.stopPython();
+        PyLib.stopPython();
     }
 
     @Test
@@ -54,12 +54,12 @@ public class PyModuleTest {
     }
 
     // see https://github.com/bcdev/jpy/issues/26
-    @Test
-    public void testCreateAndCallProxyMultiThreaded() throws Exception {
-        PyObjectTest.addTestDirToPythonSysPath();
-        PyModule procModule = PyModule.importModule("proc_module");
-        PyObjectTest.testCallProxyMultiThreaded(procModule);
-    }
+    //@Test
+    //public void testCreateAndCallProxyMultiThreaded() throws Exception {
+    //    PyObjectTest.addTestDirToPythonSysPath();
+    //    PyModule procModule = PyModule.importModule("proc_module");
+    //    PyObjectTest.testCallProxyMultiThreaded(procModule);
+    //}
 
     // see: https://github.com/bcdev/jpy/issues/39: Improve Java exception messages on Python errors #39
     @Test

--- a/src/test/java/org/jpy/PyModuleTest.java
+++ b/src/test/java/org/jpy/PyModuleTest.java
@@ -16,10 +16,9 @@
 
 package org.jpy;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.*;
+
+import java.io.File;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -30,25 +29,26 @@ import static org.junit.Assert.assertTrue;
  */
 public class PyModuleTest {
 
-    @BeforeClass
-    public static void setUp() throws Exception {
+    @Before
+    public void setUp() throws Exception {
         //System.out.println("PyModuleTest: Current thread: " + Thread.currentThread());
 
-        PyLib.startPython();
+        String importPath = new File("src/test/python/fixtures").getCanonicalPath();
+        PyLib.startPython(importPath);
         assertEquals(true, PyLib.isPythonRunning());
 
         //PyLib.Diag.setFlags(PyLib.Diag.F_METH);
     }
 
-    @AfterClass
-    public static void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         PyLib.Diag.setFlags(PyLib.Diag.F_OFF);
         PyLib.stopPython();
     }
 
     @Test
     public void testCreateAndCallProxySingleThreaded() throws Exception {
-        PyObjectTest.addTestDirToPythonSysPath();
+        //PyObjectTest.addTestDirToPythonSysPath();
         PyModule procModule = PyModule.importModule("proc_module");
         PyObjectTest.testCallProxySingleThreaded(procModule);
     }
@@ -56,7 +56,7 @@ public class PyModuleTest {
     // see https://github.com/bcdev/jpy/issues/26
     @Test
     public void testCreateAndCallProxyMultiThreaded() throws Exception {
-        PyObjectTest.addTestDirToPythonSysPath();
+        //PyObjectTest.addTestDirToPythonSysPath();
         PyModule procModule = PyModule.importModule("proc_module");
         PyObjectTest.testCallProxyMultiThreaded(procModule);
     }
@@ -64,7 +64,7 @@ public class PyModuleTest {
     // see: https://github.com/bcdev/jpy/issues/39: Improve Java exception messages on Python errors #39
     @Test
     public void testPythonErrorMessages() throws Exception {
-        PyObjectTest.addTestDirToPythonSysPath();
+        //PyObjectTest.addTestDirToPythonSysPath();
         PyModule raiserModule = PyModule.importModule("raise_errors");
         for (int i=0;i < 10;i++) {
             try {

--- a/src/test/java/org/jpy/PyObjectTest.java
+++ b/src/test/java/org/jpy/PyObjectTest.java
@@ -245,14 +245,11 @@ public class PyObjectTest {
 
         List<Future<String>> futures;
         try {
-            futures = executorService.invokeAll(Arrays.asList(new ProcessorTask(processor, 100, 100)), 10, TimeUnit.SECONDS);
-            /*
+
             futures = executorService.invokeAll(Arrays.asList(new ProcessorTask(processor, 100, 100),
                     new ProcessorTask(processor, 200, 100),
                     new ProcessorTask(processor, 100, 200),
-                    new ProcessorTask(processor, 200, 200)));
-            */
-            //executorService.awaitTermination(1, TimeUnit.MINUTES);
+                    new ProcessorTask(processor, 200, 200)), 10, TimeUnit.SECONDS);
 
             result = processor.dispose();
             assertEquals("dispose", result);

--- a/src/test/java/org/jpy/PyObjectTest.java
+++ b/src/test/java/org/jpy/PyObjectTest.java
@@ -16,11 +16,8 @@
 
 package org.jpy;
 
-import org.junit.Assert;
+import org.junit.*;
 import org.jpy.fixtures.Processor;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,18 +32,20 @@ import static org.junit.Assert.*;
  * @author Norman Fomferra
  */
 public class PyObjectTest {
-    @BeforeClass
-    public static void setUp() throws Exception {
-        //System.out.println("PyModuleTest: Current thread: " + Thread.currentThread());
 
-        PyLib.startPython();
+    @Before
+    public void setUp() throws Exception {
+        //System.out.println("PyModuleTest: Current thread: " + Thread.currentThread());
+        String importPath = new File("src/test/python/fixtures").getCanonicalPath();
+
+        PyLib.startPython(importPath);
         assertEquals(true, PyLib.isPythonRunning());
 
         PyLib.Diag.setFlags(PyLib.Diag.F_ALL);
     }
 
-    @AfterClass
-    public static void tearDown() throws Exception {
+    @After
+    public void tearDown() throws Exception {
         PyLib.Diag.setFlags(PyLib.Diag.F_OFF);
         PyLib.stopPython();
     }
@@ -192,7 +191,7 @@ public class PyObjectTest {
 
     @Test
     public void testCreateProxyAndCallSingleThreaded() throws Exception {
-        addTestDirToPythonSysPath();
+        //addTestDirToPythonSysPath();
         PyModule procModule = PyModule.importModule("proc_class");
         PyObject procObj = procModule.call("Processor");
         testCallProxySingleThreaded(procObj);
@@ -201,7 +200,7 @@ public class PyObjectTest {
     // see https://github.com/bcdev/jpy/issues/26
     @Test
     public void testCreateProxyAndCallMultiThreaded() throws Exception {
-        addTestDirToPythonSysPath();
+        //addTestDirToPythonSysPath();
         //PyLib.Diag.setFlags(PyLib.Diag.F_ALL);
         PyModule procModule = PyModule.importModule("proc_class");
         PyObject procObj = procModule.call("Processor");

--- a/src/test/java/org/jpy/PyObjectTest.java
+++ b/src/test/java/org/jpy/PyObjectTest.java
@@ -42,7 +42,7 @@ public class PyObjectTest {
         PyLib.startPython();
         assertEquals(true, PyLib.isPythonRunning());
 
-        //PyLib.Diag.setFlags(PyLib.Diag.F_METH);
+        PyLib.Diag.setFlags(PyLib.Diag.F_ALL);
     }
 
     @AfterClass
@@ -205,7 +205,7 @@ public class PyObjectTest {
         //PyLib.Diag.setFlags(PyLib.Diag.F_ALL);
         PyModule procModule = PyModule.importModule("proc_class");
         PyObject procObj = procModule.call("Processor");
-        //PyLib.Diag.setFlags(PyLib.Diag.F_ALL);
+        PyLib.Diag.setFlags(PyLib.Diag.F_ALL);
         testCallProxyMultiThreaded(procObj);
         //PyLib.Diag.setFlags(PyLib.Diag.F_OFF);
     }

--- a/src/test/java/org/jpy/PyObjectTest.java
+++ b/src/test/java/org/jpy/PyObjectTest.java
@@ -245,12 +245,11 @@ public class PyObjectTest {
 
         List<Future<String>> futures;
         try {
-
             futures = executorService.invokeAll(Arrays.asList(new ProcessorTask(processor, 100, 100),
                     new ProcessorTask(processor, 200, 100),
                     new ProcessorTask(processor, 100, 200),
                     new ProcessorTask(processor, 200, 200)), 10, TimeUnit.SECONDS);
-
+=
             result = processor.dispose();
             assertEquals("dispose", result);
 
@@ -298,10 +297,7 @@ public class PyObjectTest {
 
         @Override
         public String call() throws Exception {
-            System.out.println(String.format("...call() started for task %s", Thread.currentThread()));
-            String result =  processor.computeTile(x, y, new float[100 * 100]);
-            System.out.println(String.format("....call() complete for task %s", Thread.currentThread()));
-            return result;
+            return processor.computeTile(x, y, new float[100 * 100]);
         }
     }
 }

--- a/src/test/java/org/jpy/PyObjectTest.java
+++ b/src/test/java/org/jpy/PyObjectTest.java
@@ -245,10 +245,13 @@ public class PyObjectTest {
 
         List<Future<String>> futures;
         try {
+            futures = executorService.invokeAll(Arrays.asList(new ProcessorTask(processor, 100, 100)), 10, TimeUnit.SECONDS);
+            /*
             futures = executorService.invokeAll(Arrays.asList(new ProcessorTask(processor, 100, 100),
                     new ProcessorTask(processor, 200, 100),
                     new ProcessorTask(processor, 100, 200),
                     new ProcessorTask(processor, 200, 200)));
+            */
             //executorService.awaitTermination(1, TimeUnit.MINUTES);
 
             result = processor.dispose();
@@ -298,7 +301,10 @@ public class PyObjectTest {
 
         @Override
         public String call() throws Exception {
-            return processor.computeTile(x, y, new float[100 * 100]);
+            System.out.println(String.format("...call() started for task %s", Thread.currentThread()));
+            String result =  processor.computeTile(x, y, new float[100 * 100]);
+            System.out.println(String.format("....call() complete for task %s", Thread.currentThread()));
+            return result;
         }
     }
 }

--- a/src/test/java/org/jpy/PyObjectTest.java
+++ b/src/test/java/org/jpy/PyObjectTest.java
@@ -48,7 +48,7 @@ public class PyObjectTest {
     @AfterClass
     public static void tearDown() throws Exception {
         PyLib.Diag.setFlags(PyLib.Diag.F_OFF);
-        //PyLib.stopPython();
+        PyLib.stopPython();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/src/test/java/org/jpy/PyObjectTest.java
+++ b/src/test/java/org/jpy/PyObjectTest.java
@@ -249,7 +249,7 @@ public class PyObjectTest {
                     new ProcessorTask(processor, 200, 100),
                     new ProcessorTask(processor, 100, 200),
                     new ProcessorTask(processor, 200, 200)), 10, TimeUnit.SECONDS);
-=
+
             result = processor.dispose();
             assertEquals("dispose", result);
 

--- a/src/test/java/org/jpy/UseCases.java
+++ b/src/test/java/org/jpy/UseCases.java
@@ -16,6 +16,8 @@
 
 package org.jpy;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,10 +33,19 @@ import static org.junit.Assert.assertTrue;
  */
 public class UseCases {
 
+    @Before
+    public void setUp() {
+      PyLib.startPython();
+    }
+
+    @After
+    public void tearDown() {
+      PyLib.stopPython();
+    }
+
     @Test
     public void modifyPythonSysPath() {
 
-        PyLib.startPython();
         PyModule builtinsMod = PyModule.getBuiltins();
 
         PyModule sysMod = PyModule.importModule("sys");
@@ -57,8 +68,6 @@ public class UseCases {
         //}
 
         /////////////////////////////////////////////////
-
-        //PyLib.stopPython();
     }
 
     @Test
@@ -79,8 +88,6 @@ public class UseCases {
         assertEquals("abc", paramStrValue);
 
         /////////////////////////////////////////////////
-
-        PyLib.stopPython();
     }
 
     @Test
@@ -116,8 +123,6 @@ public class UseCases {
         assertTrue(callsPerMilli > 1.0);
 
         /////////////////////////////////////////////////
-
-        PyLib.stopPython();
     }
 
     static {

--- a/src/test/java/org/jpy/UseCases.java
+++ b/src/test/java/org/jpy/UseCases.java
@@ -80,7 +80,7 @@ public class UseCases {
 
         /////////////////////////////////////////////////
 
-        //PyLib.stopPython();
+        PyLib.stopPython();
     }
 
     @Test
@@ -117,7 +117,7 @@ public class UseCases {
 
         /////////////////////////////////////////////////
 
-        //PyLib.stopPython();
+        PyLib.stopPython();
     }
 
     static {


### PR DESCRIPTION
I believe I've fixed the issues starting and stopping the Python interpreter from Java. It involves three parts:

- making sure to call `PyGILState_Ensure()` before `Py_Finalize()`
- reseting the `JPy_InitThreads` flag to `0`
- resetting the JPY bridge state by calling `JPy_free()`

I've added a test that starts and stops the interpreter twice using calls to `PyLib.startPython()/PyLib.stopPython()`.

I also tweaked the tests to use the JUnit `@Before/@After` annotations so each test in the test classes gets a brand new interpreter state.

I've been able to test on macOS using CPython 2.7 and 3.5 and both have all tests passing.