### PR TITLE
Maven generates an auto installable jar with C libraries embedded.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,10 @@ Version 0.9
 =============
 
 * Extended unit level tests
+* Maven generates an auto installable jar with C libraries embedded.
+  Only tested on Linux.
+  When jpy is invoked from the JVM, C libraries are extracted to the temporal directory and jpy library is initialized.
+  Therefore there is not need to install JPY by compiling jpy sources. It is enough to use the generated jar file.
 
 
 Version 0.8.1

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,34 @@
                     </links>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <id>copy-binaries</id>
+                        <phase>compile</phase>
+                        <configuration>
+                            <target>
+                                <copy todir="${project.build.outputDirectory}" flatten="true">
+                                    <fileset dir="${basedir}/build">
+                                        <include name="**/*.so"/>
+                                        <include name="**/*.dll"/>
+                                        <include name="**/*.properties"/>
+                                    </fileset>
+                                </copy>
+                                <move
+                                        file="${project.build.outputDirectory}/jpyconfig.properties"
+                                        tofile="${project.build.outputDirectory}/jpyconfig.properties.template"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
 
         <extensions>

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ from setuptools import setup
 from setuptools.extension import Extension
 from distutils import log
 
+jpy_config = 'jpyconfig.properties'
 base_dir = os.path.dirname(os.path.abspath(__file__))
 src_main_c_dir = os.path.join(base_dir, 'src', 'main', 'c')
 src_test_py_dir = os.path.join(base_dir, 'src', 'test', 'python')
@@ -391,7 +392,7 @@ if dist.commands and len(dist.commands) > 0 \
         else:
             mvn_goal = 'test'
         mvn_args = '-DargLine=-Xmx512m -Djpy.config=' + os.path.join(build_dir,
-                                                                     'jpyconfig.properties') + ' -Djpy.debug=true'
+                                                                     jpy_config) + ' -Djpy.debug=true'
         log.info("Executing Maven goal " + repr(mvn_goal) + " with arg line " + repr(mvn_args))
         code = subprocess.call(['mvn', mvn_goal, mvn_args], shell=platform.system() == 'Windows')
         if code:

--- a/src/main/java/org/jpy/DL.java
+++ b/src/main/java/org/jpy/DL.java
@@ -16,6 +16,8 @@
 
 package org.jpy;
 
+import java.io.File;
+
 /**
  * A replacement for {@link System#load(String)} with support for POSIX {@code dlopen} flags.
  * <p>
@@ -62,13 +64,15 @@ public class DL {
     public static native String dlerror();
 
     static {
-        try {
-            System.loadLibrary("jdl");
-        } catch (Throwable t) {
-            String jdlLibPath = System.getProperty("jpy.jdlLib");
-            if (jdlLibPath != null) {
-                System.load(jdlLibPath);
-            } else {
+        String jdlLibPath = System.getProperty("jpy.jdlLib");
+        if(jdlLibPath != null && new File(jdlLibPath).exists()) {
+            // load the library from the path.
+            System.load(jdlLibPath);
+        } else {
+            // try to load it using default libs.
+            try {
+                System.loadLibrary("jdl");
+            } catch (Throwable t) {
                 throw new RuntimeException("Failed to load 'jdl' shared library. You can use system property 'jpy.jdlLib' to specify it.", t);
             }
         }


### PR DESCRIPTION
Only tested on Linux.
When jpy is invoked from the JVM, C libraries are extracted to the
temporal directory and jpy library is initialized.
Therefore there is not need to install JPY by compiling jpy sources.
It is enough to use the generated jar file.