### PR TITLE
Issue 81 - resolves issues reading sys.argv from Java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ local.dat
 setup.out
 *.pyc
 jpy.egg-info
+lib/
+.vagrant
+Vagrantfile

--- a/src/main/c/jni/org_jpy_PyLib.c
+++ b/src/main/c/jni/org_jpy_PyLib.c
@@ -131,6 +131,7 @@ JNIEXPORT jboolean JNICALL Java_org_jpy_PyLib_startPython0
 
     if (!pyInit) {
         Py_Initialize();
+        PySys_SetArgvEx(0, NULL, 0);
         PyLib_RedirectStdOut();
         pyInit = Py_IsInitialized();
     }

--- a/src/test/java/org/jpy/PyLibTest.java
+++ b/src/test/java/org/jpy/PyLibTest.java
@@ -35,6 +35,17 @@ public class PyLibTest {
     }
 
     @Test
+    public void testGettingSysArgv() throws Exception {
+        // Since sys.argv is really part of the C-based sys module, there
+        // are special hooks embedded python systems need to call to set it up.
+        PyModule sys = PyModule.importModule("sys");
+        String[] argv = sys.getAttribute("argv", String[].class);
+        assertNotNull(argv);
+        assertEquals(1, argv.length);
+        assertTrue(argv[0].isEmpty());
+    }
+
+    @Test
     public void testGetPythonVersion() throws Exception {
         String pythonVersion = PyLib.getPythonVersion();
         System.out.println("pythonVersion = " + pythonVersion);


### PR DESCRIPTION
Found a simple fix for #81. 

Might be good to consider a new feature allowing us to set the argv values using the Python API call `PyAPI_FUNC(void) PySys_SetArgvEx(int, char **, int)`. It was more than a simple change so I'll save that for the future :-)

With this change, you'll get the same behavior as if you created a module like:
```python
# mymodule.py
import sys

def print_argv():
    print(sys.argv)
```
Calling `mymodule.print_argv()` from another module or the Python repl will return `['']` on both CPython 2.7 and 3.6.

The included test checks that the same behavior applies.
