### PR TITLE
Possible fix for #74. 

### DIFF
--- a/src/main/c/jpy_jtype.c
+++ b/src/main/c/jpy_jtype.c
@@ -58,24 +58,30 @@ JPy_JType* JType_GetTypeForName(JNIEnv* jenv, const char* typeName, jboolean res
     const char* resourceName;
     jclass classRef;
 
+    JPy_JType* javaType = NULL;
     if (strcmp(typeName, "boolean") == 0) {
-        return JPy_JBoolean;
+        javaType = JPy_JBoolean;
     } else if (strcmp(typeName, "char") == 0) {
-        return JPy_JChar;
+        javaType = JPy_JChar;
     } else if (strcmp(typeName, "byte") == 0) {
-        return JPy_JByte;
+        javaType = JPy_JByte;
     } else if (strcmp(typeName, "short") == 0) {
-        return JPy_JShort;
+        javaType = JPy_JShort;
     } else if (strcmp(typeName, "int") == 0) {
-        return JPy_JInt;
+        javaType = JPy_JInt;
     } else if (strcmp(typeName, "long") == 0) {
-        return JPy_JLong;
+        javaType = JPy_JLong;
     } else if (strcmp(typeName, "float") == 0) {
-        return JPy_JFloat;
+        javaType =  JPy_JFloat;
     } else if (strcmp(typeName, "double") == 0) {
-        return JPy_JDouble;
+        javaType =  JPy_JDouble;
     } else if (strcmp(typeName, "void") == 0) {
-        return JPy_JVoid;
+        javaType =  JPy_JVoid;
+    }
+
+    if(javaType != NULL) {
+      Py_INCREF(javaType);
+      return javaType;
     }
 
     if (strchr(typeName, '.') != NULL) {
@@ -207,7 +213,8 @@ JPy_JType* JType_GetType(JNIEnv* jenv, jclass classRef, jboolean resolve)
             return NULL;
         }
     }
-
+    
+    Py_INCREF(type);
     return type;
 }
 
@@ -2000,5 +2007,3 @@ PyTypeObject JType_Type = {
     NULL,                         /* tp_alloc */
     (newfunc) NULL,               /* tp_new=NULL --> JType instances cannot be created from Python. */
 };
-
-

--- a/src/test/python/jpy_gettype_test.py
+++ b/src/test/python/jpy_gettype_test.py
@@ -52,13 +52,25 @@ class TestGetClass(unittest.TestCase):
 
 
     def test_get_class_of_unknown_type(self):
-        with  self.assertRaises(ValueError) as e:
+        with self.assertRaises(ValueError) as e:
             String = jpy.get_type('java.lang.Spring')
         self.assertEqual(str(e.exception), "Java class 'java.lang.Spring' not found")
 
         with  self.assertRaises(ValueError) as e:
             IntArray = jpy.get_type('int[]')
         self.assertEqual(str(e.exception), "Java class 'int[]' not found")
+
+    def test_issue_74(self):
+        """
+        Try to create enough references to trigger collection by Python.
+        """
+        java_types = ['boolean', 'char', 'byte', 'short', 'int', 'long',
+            'float', 'double', 'void', 'java.lang.String']
+
+        for java_type in java_types:
+            for i in range(200):
+                jpy.get_type(java_type)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I believe Python was garbage collecting old java type instances and trying to decrement their reference counts, but they were never incremented. Added calls to Py_INCREF before returning the java types.

I added a test that tries all primitives (they also exhibited the behavior) and `java.lang.String` to test an Object. 

I manually tested in CPython 2.7 and 3.6 on macOS.