### PR TITLE
jpy_jtype.c: Use getMethods instead of getDeclaredMethods.

### DIFF
--- a/src/main/c/jpy_jtype.c
+++ b/src/main/c/jpy_jtype.c
@@ -1075,7 +1075,7 @@ int JType_ProcessClassMethods(JNIEnv* jenv, JPy_JType* type)
     if (type->isInterface) {
         methods = (*jenv)->CallObjectMethod(jenv, classRef, JPy_Class_GetMethods_MID);
     } else {
-        methods = (*jenv)->CallObjectMethod(jenv, classRef, JPy_Class_GetDeclaredMethods_MID);
+        methods = (*jenv)->CallObjectMethod(jenv, classRef, JPy_Class_GetMethods_MID);
     }
     methodCount = (*jenv)->GetArrayLength(jenv, methods);
 


### PR DESCRIPTION
Java 8 interfaces may have default methods.  When using getMethods up the
inheritance stack, jpy wil never find them.  By using getDeclaredMethods
instead, jpy is able to find the default methods and properly invoke them.