### PR TITLE
Handle varargs method calls.

### DIFF
--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -218,6 +218,13 @@ Variables
     Here a call to the ``read`` method will modify the numpy array's content as desired and return the
     same array instance as indicated by the Java method's specification.
 
+.. py:data:: type_translations
+    :module: jpy
+
+    Contains callbacks which are called when instantiating a Python object from a Java object.
+    After the standard wrapping of the Java object as a Python object, the Java type name is looked up in this
+    dictionary.  If the returned item is a callable, the callable is called with the JPy object as an argument,
+    and the callable's result is returned to the user.
 
 .. py:data:: diag
     :module: jpy

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ python_java_jpy_tests = [
     os.path.join(src_test_py_dir, 'jpy_typeconv_test.py'),
     os.path.join(src_test_py_dir, 'jpy_typeres_test.py'),
     os.path.join(src_test_py_dir, 'jpy_modretparam_test.py'),
+    os.path.join(src_test_py_dir, 'jpy_translation_test.py'),
     os.path.join(src_test_py_dir, 'jpy_gettype_test.py'),
 ]
 
@@ -200,7 +201,7 @@ def test_python_java_classes():
     """ Run Python tests against JPY test classes """
     sub_env = {'PYTHONPATH': _build_dir()}
 
-    log.info('Executing Python unit tests (against Java runtime classes)...')
+    log.info('Executing Python unit tests (against JPY test classes)...')
     return jpyutil._execute_python_scripts(python_java_jpy_tests,
                                             env=sub_env)
     

--- a/src/main/c/jpy_jmethod.c
+++ b/src/main/c/jpy_jmethod.c
@@ -29,6 +29,7 @@ JPy_JMethod* JMethod_New(JPy_JType* declaringClass,
                          JPy_ParamDescriptor* paramDescriptors,
                          JPy_ReturnDescriptor* returnDescriptor,
                          jboolean isStatic,
+                         jboolean isVarArgs,
                          jmethodID mid)
 {
     PyTypeObject* type = &JMethod_Type;
@@ -41,6 +42,7 @@ JPy_JMethod* JMethod_New(JPy_JType* declaringClass,
     method->paramDescriptors = paramDescriptors;
     method->returnDescriptor = returnDescriptor;
     method->isStatic = isStatic;
+    method->isVarArgs = isVarArgs;
     method->mid = mid;
 
     Py_INCREF(declaringClass);
@@ -85,7 +87,7 @@ void JMethod_Del(JPy_JMethod* method)
  * Returns the sum of the i-th argument against the i-th Java parameter.
  * The maximum match value returned is 100 * method->paramCount.
  */
-int JMethod_MatchPyArgs(JNIEnv* jenv, JPy_JType* declaringClass, JPy_JMethod* method, int argCount, PyObject* pyArgs)
+int JMethod_MatchPyArgs(JNIEnv* jenv, JPy_JType* declaringClass, JPy_JMethod* method, int argCount, PyObject* pyArgs, int *isVarArgArray)
 {
     JPy_ParamDescriptor* paramDescriptor;
     PyObject* pyArg;
@@ -93,30 +95,53 @@ int JMethod_MatchPyArgs(JNIEnv* jenv, JPy_JType* declaringClass, JPy_JMethod* me
     int matchValue;
     int i;
     int i0;
+    int iLast;
+    *isVarArgArray = 0;
 
     if (method->isStatic) {
-        //printf("Static! method->paramCount=%d, argCount=%d\n", method->paramCount, argCount);
-        if (method->paramCount != argCount) {
-            JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: argument count mismatch (matchValue=0)\n");
-            // argument count mismatch
-            return 0;
-        }
-        if (method->paramCount == 0) {
-            JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: no-argument static method (matchValue=100)\n");
-            // There can't be any other static method overloads with no parameters
-            return 100;
-        }
+        if (method->isVarArgs) {
+            if(argCount < method->paramCount - 1) {
+                JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: var args argument count mismatch java=%d, python=%d (matchValue=0)\n", method->paramCount, argCount);
+                // argument count mismatch
+                return 0;
+            }
+            iLast = method->paramCount - 1;
+        } else {
+            if (method->paramCount != argCount) {
+                JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: argument count mismatch (matchValue=0)\n");
+                // argument count mismatch
+                return 0;
+            }
+            if (method->paramCount == 0) {
+                JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: no-argument static method (matchValue=100)\n");
+                // There can't be any other static method overloads with no parameters
+                return 100;
+            }
 
-        i0 = 0;
+            iLast = argCount;
+        }
         matchValueSum = 0;
+        i0 = 0;
     } else {
         PyObject* self;
-        //printf("Non-Static! method->paramCount=%d, argCount=%d\n", method->paramCount, argCount);
-        if (method->paramCount != argCount - 1) {
+        //printf("Non-Static! method->paramCount=%d, argCount=%d, isVarArg=%d\n", method->paramCount, argCount, method->isVarArgs);
+
+        if (method->isVarArgs) {
+            if (argCount < method->paramCount) {
+                JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: var args argument count mismatch java=%d, python=%d (matchValue=0)\n", method->paramCount, argCount);
+                // argument count mismatch
+                return 0;
+            }
+            iLast = method->paramCount;
+        }
+        else if (method->paramCount != argCount - 1) {
             JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: argument count mismatch (matchValue=0)\n");
             // argument count mismatch
             return 0;
+        } else {
+            iLast = method->paramCount + 1;
         }
+
         self = PyTuple_GetItem(pyArgs, 0);
         if (self == Py_None) {
             JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: self argument is None (matchValue=0)\n");
@@ -141,8 +166,7 @@ int JMethod_MatchPyArgs(JNIEnv* jenv, JPy_JType* declaringClass, JPy_JMethod* me
     }
 
     paramDescriptor = method->paramDescriptors;
-    for (i = i0; i < argCount; i++) {
-
+    for (i = i0; i < iLast; i++) {
         pyArg = PyTuple_GetItem(pyArgs, i);
         matchValue = paramDescriptor->MatchPyArg(jenv, paramDescriptor, pyArg);
 
@@ -156,6 +180,34 @@ int JMethod_MatchPyArgs(JNIEnv* jenv, JPy_JType* declaringClass, JPy_JMethod* me
 
         matchValueSum += matchValue;
         paramDescriptor++;
+    }
+    if (method->isVarArgs) {
+        int singleMatchValue = 0;
+
+        JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: isVarArgs, argCount = %d, i=%d\n", argCount, i);
+
+        if (argCount - i == 0) {
+            matchValueSum += 10;
+            JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: isVarArgs, argCount = %d, paramCount = %d, matchValueSum=%d\n", argCount, method->paramCount, matchValueSum);
+        } else if (argCount - i == 1) {
+            // if we have exactly one argument, which matches our array type, then we can use that as an array
+            pyArg = PyTuple_GetItem(pyArgs, i);
+            singleMatchValue = paramDescriptor->MatchPyArg(jenv, paramDescriptor, pyArg);
+            JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: isVarArgs, argCount = %d, paramCount = %d, starting singleMatchValue=%d\n", argCount, method->paramCount, singleMatchValue);
+        }
+
+        JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: isVarArgs, argCount = %d, paramCount = %d, starting matchValue=%d\n", argCount, method->paramCount, matchValueSum);
+        matchValue = paramDescriptor->MatchVarArgPyArg(jenv, paramDescriptor, pyArgs, i);
+        JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JMethod_MatchPyArgs: isVarArgs, paramDescriptor->type->javaName='%s', matchValue=%d\n", paramDescriptor->type->javaName, matchValue);
+        if (matchValue == 0 && singleMatchValue == 0) {
+            return 0;
+        }
+        if (matchValue > singleMatchValue) {
+            matchValueSum += matchValue;
+        } else {
+            matchValueSum += singleMatchValue;
+            *isVarArgArray = 1;
+        }
     }
 
     //printf("JMethod_MatchPyArgs 7\n");
@@ -185,7 +237,7 @@ PyObject* JMethod_FromJObject(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyArg
 /**
  * Invoke a method. We have already ensured that the Python arguments and expected Java parameters match.
  */
-PyObject* JMethod_InvokeMethod(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyArgs)
+PyObject* JMethod_InvokeMethod(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyArgs, int isVarArgsArray)
 {
     jvalue* jArgs;
     JPy_ArgDisposer* argDisposers;
@@ -195,7 +247,7 @@ PyObject* JMethod_InvokeMethod(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyAr
     jclass classRef;
 
     //printf("JMethod_InvokeMethod 1: typeCode=%c\n", typeCode);
-    if (JMethod_CreateJArgs(jenv, method, pyArgs, &jArgs, &argDisposers) < 0) {
+    if (JMethod_CreateJArgs(jenv, method, pyArgs, &jArgs, &argDisposers, isVarArgsArray) < 0) {
         return NULL;
     }
 
@@ -325,10 +377,11 @@ error:
     return returnValue;
 }
 
-int JMethod_CreateJArgs(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyArgs, jvalue** argValuesRet, JPy_ArgDisposer** argDisposersRet)
+int JMethod_CreateJArgs(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyArgs, jvalue** argValuesRet, JPy_ArgDisposer** argDisposersRet, int isVarArgsArray)
 {
     JPy_ParamDescriptor* paramDescriptor;
-    int i, i0, argCount;
+    Py_ssize_t i, i0, iLast;
+    Py_ssize_t argCount;
     PyObject* pyArg;
     jvalue* jValue;
     jvalue* jValues;
@@ -343,10 +396,17 @@ int JMethod_CreateJArgs(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyArgs, jva
 
     argCount = PyTuple_Size(pyArgs);
 
-    i0 = argCount - method->paramCount;
-    if (!(i0 == 0 || i0 == 1)) {
-        PyErr_SetString(PyExc_RuntimeError, "internal error");
-        return -1;
+    if (method->isVarArgs) {
+        // need to know if we expect a self parameter
+        i0 = method->isStatic ? 0 : 1;
+        iLast = method->isStatic ? method->paramCount - 1 : method->paramCount;
+    } else {
+        i0 = argCount - method->paramCount;
+        if (!(i0 == 0 || i0 == 1)) {
+            PyErr_SetString(PyExc_RuntimeError, "internal error");
+            return -1;
+        }
+        iLast = argCount;
     }
 
     jValues = PyMem_New(jvalue, method->paramCount);
@@ -365,7 +425,7 @@ int JMethod_CreateJArgs(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyArgs, jva
     paramDescriptor = method->paramDescriptors;
     jValue = jValues;
     argDisposer = argDisposers;
-    for (i = i0; i < argCount; i++) {
+    for (i = i0; i < iLast; i++) {
         pyArg = PyTuple_GetItem(pyArgs, i);
         jValue->l = 0;
         argDisposer->data = NULL;
@@ -378,6 +438,28 @@ int JMethod_CreateJArgs(JNIEnv* jenv, JPy_JMethod* method, PyObject* pyArgs, jva
         paramDescriptor++;
         jValue++;
         argDisposer++;
+    }
+    if (method->isVarArgs) {
+        if (isVarArgsArray) {
+            pyArg = PyTuple_GetItem(pyArgs, i);
+            jValue->l = 0;
+            argDisposer->data = NULL;
+            argDisposer->DisposeArg = NULL;
+            if (paramDescriptor->ConvertPyArg(jenv, paramDescriptor, pyArg, jValue, argDisposer) < 0) {
+                PyMem_Del(jValues);
+                PyMem_Del(argDisposers);
+                return -1;
+            }
+        } else {
+            jValue->l = 0;
+            argDisposer->data = NULL;
+            argDisposer->DisposeArg = NULL;
+            if (paramDescriptor->ConvertVarArgPyArg(jenv, paramDescriptor, pyArgs, i, jValue, argDisposer) < 0) {
+                PyMem_Del(jValues);
+                PyMem_Del(argDisposers);
+                return -1;
+            }
+        }
     }
 
     *argValuesRet = jValues;
@@ -611,19 +693,22 @@ typedef struct JPy_MethodFindResult
     JPy_JMethod* method;
     int matchValue;
     int matchCount;
+    int isVarArgsArray;
 }
 JPy_MethodFindResult;
 
 JPy_JMethod* JOverloadedMethod_FindMethod0(JNIEnv* jenv, JPy_JOverloadedMethod* overloadedMethod, PyObject* pyArgs, JPy_MethodFindResult* result)
 {
-    int overloadCount;
-    int argCount;
+    Py_ssize_t overloadCount;
+    Py_ssize_t argCount;
     int matchCount;
     int matchValue;
     int matchValueMax;
     JPy_JMethod* currMethod;
     JPy_JMethod* bestMethod;
     int i;
+    int currentIsVarArgsArray;
+    int bestIsVarArgsArray;
 
     result->method = NULL;
     result->matchValue = 0;
@@ -640,25 +725,26 @@ JPy_JMethod* JOverloadedMethod_FindMethod0(JNIEnv* jenv, JPy_JOverloadedMethod* 
     matchValueMax = -1;
     bestMethod = NULL;
 
-    JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JOverloadedMethod_FindMethod0: method '%s#%s': overloadCount=%d\n",
-                              overloadedMethod->declaringClass->javaName, JPy_AS_UTF8(overloadedMethod->name), overloadCount);
+    JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JOverloadedMethod_FindMethod0: method '%s#%s': overloadCount=%d, argCount=%d\n",
+                              overloadedMethod->declaringClass->javaName, JPy_AS_UTF8(overloadedMethod->name), overloadCount, argCount);
 
     for (i = 0; i < overloadCount; i++) {
         currMethod = (JPy_JMethod*) PyList_GetItem(overloadedMethod->methodList, i);
-        matchValue = JMethod_MatchPyArgs(jenv, overloadedMethod->declaringClass, currMethod, argCount, pyArgs);
+        matchValue = JMethod_MatchPyArgs(jenv, overloadedMethod->declaringClass, currMethod, argCount, pyArgs, &currentIsVarArgsArray);
 
-        JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JOverloadedMethod_FindMethod0: methodList[%d]: paramCount=%d, matchValue=%d\n", i,
-                                  currMethod->paramCount, matchValue);
+        JPy_DIAG_PRINT(JPy_DIAG_F_METH, "JOverloadedMethod_FindMethod0: methodList[%d]: paramCount=%d, matchValue=%d, isVarArgs=%d\n", i,
+                                  currMethod->paramCount, matchValue, currMethod->isVarArgs);
 
         if (matchValue > 0) {
             if (matchValue > matchValueMax) {
                 matchValueMax = matchValue;
                 bestMethod = currMethod;
                 matchCount = 1;
+                bestIsVarArgsArray = currentIsVarArgsArray;
             } else if (matchValue == matchValueMax) {
                 matchCount++;
             }
-            if (matchValue >= 100 * argCount) {
+            if (!currMethod->isVarArgs && (matchValue >= 100 * argCount)) {
                 // we can't get any better (if so, we have an internal problem)
                 break;
             }
@@ -668,16 +754,18 @@ JPy_JMethod* JOverloadedMethod_FindMethod0(JNIEnv* jenv, JPy_JOverloadedMethod* 
     if (bestMethod == NULL) {
         matchValueMax = 0;
         matchCount = 0;
+        bestIsVarArgsArray = 0;
     }
 
     result->method = bestMethod;
     result->matchValue = matchValueMax;
     result->matchCount = matchCount;
+    result->isVarArgsArray = bestIsVarArgsArray;
 
     return bestMethod;
 }
 
-JPy_JMethod* JOverloadedMethod_FindMethod(JNIEnv* jenv, JPy_JOverloadedMethod* overloadedMethod, PyObject* pyArgs, jboolean visitSuperClass)
+JPy_JMethod* JOverloadedMethod_FindMethod(JNIEnv* jenv, JPy_JOverloadedMethod* overloadedMethod, PyObject* pyArgs, jboolean visitSuperClass, int *isVarArgsArray)
 {
     JPy_JOverloadedMethod* currentOM;
     JPy_MethodFindResult result;
@@ -700,6 +788,7 @@ JPy_JMethod* JOverloadedMethod_FindMethod(JNIEnv* jenv, JPy_JOverloadedMethod* o
     bestResult.method = NULL;
     bestResult.matchValue = 0;
     bestResult.matchCount = 0;
+    bestResult.isVarArgsArray = 0;
 
     currentOM = overloadedMethod;
     while (1) {
@@ -708,8 +797,11 @@ JPy_JMethod* JOverloadedMethod_FindMethod(JNIEnv* jenv, JPy_JOverloadedMethod* o
             return NULL;
         }
         if (result.method != NULL) {
-            if (result.matchValue >= 100 * argCount) {
+            // in the case where we have a match count that is perfect, but more than one match; the super class might
+            // have a better match count, because varargs can have fewer arguments than actual parameters.
+            if (result.matchValue >= 100 * argCount && result.matchCount == 1) {
                 // We can't get any better.
+                *isVarArgsArray = result.isVarArgsArray;
                 return result.method;
             } else if (result.matchValue > 0 && result.matchValue > bestResult.matchValue) {
                 // We may have better matching methods overloads in the super class (if any)
@@ -740,6 +832,7 @@ JPy_JMethod* JOverloadedMethod_FindMethod(JNIEnv* jenv, JPy_JOverloadedMethod* o
                 PyErr_SetString(PyExc_RuntimeError, "ambiguous Java method call, too many matching method overloads found");
                 return NULL;
             } else {
+                *isVarArgsArray = bestResult.isVarArgsArray;
                 return bestResult.method;
             }
         } else {
@@ -795,15 +888,16 @@ PyObject* JOverloadedMethod_call(JPy_JOverloadedMethod* self, PyObject *args, Py
 {
     JNIEnv* jenv;
     JPy_JMethod* method;
+    int isVarArgsArray;
 
     JPy_GET_JNI_ENV_OR_RETURN(jenv, NULL)
 
-    method = JOverloadedMethod_FindMethod(jenv, self, args, JNI_TRUE);
+    method = JOverloadedMethod_FindMethod(jenv, self, args, JNI_TRUE, &isVarArgsArray);
     if (method == NULL) {
         return NULL;
     }
 
-    return JMethod_InvokeMethod(jenv, method, args);
+    return JMethod_InvokeMethod(jenv, method, args, isVarArgsArray);
 }
 
 /**

--- a/src/main/c/jpy_jmethod.h
+++ b/src/main/c/jpy_jmethod.h
@@ -38,6 +38,8 @@ typedef struct
     int paramCount;
     // Method is static?
     char isStatic;
+    // Method is varargs?
+    char isVarArgs;
     // Method parameter types. Will be NULL, if parameter_count == 0.
     JPy_ParamDescriptor* paramDescriptors;
     // Method return type. Will be NULL for constructors.
@@ -73,7 +75,7 @@ JPy_JOverloadedMethod;
  */
 extern PyTypeObject JOverloadedMethod_Type;
 
-JPy_JMethod*           JOverloadedMethod_FindMethod(JNIEnv* jenv, JPy_JOverloadedMethod* overloadedMethod, PyObject* argTuple, jboolean visitSuperClass);
+JPy_JMethod*           JOverloadedMethod_FindMethod(JNIEnv* jenv, JPy_JOverloadedMethod* overloadedMethod, PyObject* argTuple, jboolean visitSuperClass, int *isVarArgsArray);
 JPy_JMethod*           JOverloadedMethod_FindStaticMethod(JPy_JOverloadedMethod* overloadedMethod, PyObject* argTuple);
 JPy_JOverloadedMethod* JOverloadedMethod_New(JPy_JType* declaringClass, PyObject* name, JPy_JMethod* method);
 int                    JOverloadedMethod_AddMethod(JPy_JOverloadedMethod* overloadedMethod, JPy_JMethod* method);
@@ -84,13 +86,14 @@ JPy_JMethod* JMethod_New(JPy_JType* declaringClass,
                          JPy_ParamDescriptor* paramDescriptors,
                          JPy_ReturnDescriptor* returnDescriptor,
                          jboolean isStatic,
+                         jboolean isVarArgs,
                          jmethodID mid);
 
 void JMethod_Del(JPy_JMethod* method);
 
 int JMethod_ConvertToJavaValues(JNIEnv* jenv, JPy_JMethod* jMethod, int argCount, PyObject* argTuple, jvalue* jArgs);
 
-int  JMethod_CreateJArgs(JNIEnv* jenv, JPy_JMethod* jMethod, PyObject* argTuple, jvalue** jValues, JPy_ArgDisposer** jDisposers);
+int  JMethod_CreateJArgs(JNIEnv* jenv, JPy_JMethod* jMethod, PyObject* argTuple, jvalue** jValues, JPy_ArgDisposer** jDisposers, int isVarArgsArray);
 void JMethod_DisposeJArgs(JNIEnv* jenv, int paramCount, jvalue* jValues, JPy_ArgDisposer* jDisposers);
 
 #ifdef __cplusplus

--- a/src/main/c/jpy_jobj.c
+++ b/src/main/c/jpy_jobj.c
@@ -23,7 +23,7 @@
 #include "jpy_jfield.h"
 #include "jpy_conv.h"
 
-JPy_JObj* JObj_New(JNIEnv* jenv, jobject objectRef)
+PyObject* JObj_New(JNIEnv* jenv, jobject objectRef)
 {
     jclass classRef;
     JPy_JType* type;
@@ -38,8 +38,11 @@ JPy_JObj* JObj_New(JNIEnv* jenv, jobject objectRef)
     return JObj_FromType(jenv, type, objectRef);
 }
 
-JPy_JObj* JObj_FromType(JNIEnv* jenv, JPy_JType* type, jobject objectRef)
+PyObject* JObj_FromType(JNIEnv* jenv, JPy_JType* type, jobject objectRef)
 {
+    PyObject* callable;
+    PyObject* callableResult;
+
     JPy_JObj* obj;
 
     obj = (JPy_JObj*) PyObject_New(JPy_JObj, (PyTypeObject*) type);
@@ -63,7 +66,19 @@ JPy_JObj* JObj_FromType(JNIEnv* jenv, JPy_JType* type, jobject objectRef)
         array->bufferExportCount = 0;
     }
 
-    return obj;
+    callable = PyDict_GetItemString(JPy_Type_Translations, type->javaName);
+    if (callable != NULL) {
+        if (PyCallable_Check(callable)) {
+            callableResult = PyObject_CallFunction(callable, "OO", type, obj);
+            if (callableResult == NULL) {
+                return Py_None;
+            } else {
+                return callableResult;
+            }
+        }
+    }
+
+    return (PyObject *)obj;
 }
 
 /**
@@ -101,12 +116,14 @@ int JObj_init(JPy_JObj* self, PyObject* args, PyObject* kwds)
         return -1;
     }
 
-    jMethod = JOverloadedMethod_FindMethod(jenv, (JPy_JOverloadedMethod*) constructor, args, JNI_FALSE);
+    int isVarArgsArray;
+
+    jMethod = JOverloadedMethod_FindMethod(jenv, (JPy_JOverloadedMethod*) constructor, args, JNI_FALSE, &isVarArgsArray);
     if (jMethod == NULL) {
         return -1;
     }
 
-    if (JMethod_CreateJArgs(jenv, jMethod, args, &jArgs, &jDisposers) < 0) {
+    if (JMethod_CreateJArgs(jenv, jMethod, args, &jArgs, &jDisposers, isVarArgsArray) < 0) {
         return -1;
     }
 

--- a/src/main/c/jpy_jtype.h
+++ b/src/main/c/jpy_jtype.h
@@ -74,7 +74,9 @@ JPy_ArgDisposer;
 struct JPy_ParamDescriptor;
 
 typedef int (*JPy_MatchPyArg)(JNIEnv*, struct JPy_ParamDescriptor*, PyObject*);
+typedef int (*JPy_MatchVarArgPyArg)(JNIEnv*, struct JPy_ParamDescriptor*, PyObject*, int);
 typedef int (*JPy_ConvertPyArg)(JNIEnv*, struct JPy_ParamDescriptor*, PyObject*, jvalue*, JPy_ArgDisposer*);
+typedef int (*JPy_ConvertVarArgPyArg)(JNIEnv*, struct JPy_ParamDescriptor*, PyObject*, int, jvalue*, JPy_ArgDisposer*);
 
 /**
  * Method return value descriptor.
@@ -103,7 +105,9 @@ typedef struct JPy_ParamDescriptor
     jboolean isOutput;
     jboolean isReturn;
     JPy_MatchPyArg MatchPyArg;
+    JPy_MatchVarArgPyArg MatchVarArgPyArg;
     JPy_ConvertPyArg ConvertPyArg;
+    JPy_ConvertVarArgPyArg ConvertVarArgPyArg;
 }
 JPy_ParamDescriptor;
 

--- a/src/main/c/jpy_module.c
+++ b/src/main/c/jpy_module.c
@@ -85,6 +85,7 @@ static struct PyModuleDef JPy_ModuleDef =
 PyObject* JPy_Module = NULL;
 PyObject* JPy_Types = NULL;
 PyObject* JPy_Type_Callbacks = NULL;
+PyObject* JPy_Type_Translations = NULL;
 PyObject* JException_Type = NULL;
 
 // A global reference to a Java VM singleton.
@@ -321,6 +322,12 @@ PyMODINIT_FUNC JPY_MODULE_INIT_FUNC(void)
     JPy_Type_Callbacks = PyDict_New();
     Py_INCREF(JPy_Type_Callbacks);
     PyModule_AddObject(JPy_Module, JPy_MODULE_ATTR_NAME_TYPE_CALLBACKS, JPy_Type_Callbacks);
+
+    /////////////////////////////////////////////////////////////////////////
+
+    JPy_Type_Translations = PyDict_New();
+    Py_INCREF(JPy_Type_Translations);
+    PyModule_AddObject(JPy_Module, JPy_MODULE_ATTR_NAME_TYPE_TRANSLATIONS, JPy_Type_Translations);
 
     /////////////////////////////////////////////////////////////////////////
 
@@ -987,6 +994,7 @@ void JPy_free(void* unused)
     JPy_Module = NULL;
     JPy_Types = NULL;
     JPy_Type_Callbacks = NULL;
+    JPy_Type_Translations = NULL;
     JException_Type = NULL;
 
     JPy_DIAG_PRINT(JPy_DIAG_F_ALL, "JPy_free: done freeing module data\n");

--- a/src/main/c/jpy_module.h
+++ b/src/main/c/jpy_module.h
@@ -32,6 +32,7 @@ extern "C" {
 extern PyObject* JPy_Module;
 extern PyObject* JPy_Types;
 extern PyObject* JPy_Type_Callbacks;
+extern PyObject* JPy_Type_Translations;
 extern PyObject* JException_Type;
 
 extern JavaVM* JPy_JVM;
@@ -42,6 +43,7 @@ extern jboolean JPy_MustDestroyJVM;
 
 #define JPy_MODULE_ATTR_NAME_TYPES "types"
 #define JPy_MODULE_ATTR_NAME_TYPE_CALLBACKS "type_callbacks"
+#define JPy_MODULE_ATTR_NAME_TYPE_TRANSLATIONS "type_translations"
 
 
 /**

--- a/src/test/java/org/jpy/fixtures/TypeTranslationTestFixture.java
+++ b/src/test/java/org/jpy/fixtures/TypeTranslationTestFixture.java
@@ -14,36 +14,18 @@
  * limitations under the License.
  */
 
-#ifndef JPY_JOBJ_H
-#define JPY_JOBJ_H
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include "jpy_compat.h"
+package org.jpy.fixtures;
 
 /**
- * The Java Object representation in Python.
- * @see JPy_JArray
+ * Used as a test class for the test cases in jpy_retval_test.py
+ * Note: Please make sure to not add any method overloads to this class.
+ * This is done in {@link MethodOverloadTestFixture}.
+ *
+ * @author Norman Fomferra
  */
-typedef struct JPy_JObj
-{
-    PyObject_HEAD
-    jobject objectRef;
+@SuppressWarnings("UnusedDeclaration")
+public class TypeTranslationTestFixture {
+    public Thing makeThing(int value) {
+        return new Thing(value);
+    }
 }
-JPy_JObj;
-
-
-int JObj_Check(PyObject* arg);
-
-PyObject* JObj_New(JNIEnv* jenv, jobject objectRef);
-PyObject* JObj_FromType(JNIEnv* jenv, JPy_JType* type, jobject objectRef);
-
-int JObj_InitTypeSlots(PyTypeObject* type, const char* typeName, PyTypeObject* superType);
-
-
-#ifdef __cplusplus
-}  /* extern "C" */
-#endif
-#endif /* !JPY_JOBJ_H */

--- a/src/test/java/org/jpy/fixtures/VarArgsTestFixture.java
+++ b/src/test/java/org/jpy/fixtures/VarArgsTestFixture.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2015 Brockmann Consult GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jpy.fixtures;
+
+import java.lang.reflect.Array;
+
+/**
+ * Used as a test class for the test cases in jpy_overload_test.py
+ *
+ * @author Norman Fomferra
+ */
+@SuppressWarnings("UnusedDeclaration")
+public class VarArgsTestFixture {
+
+    public String join(String prefix, int ... a) {
+        return stringifyArgs(prefix, a);
+    }
+
+    public String join(String prefix, double ... a) {
+        return stringifyArgs(prefix, a);
+    }
+    public String join(String prefix, float ... a) {
+        return stringifyArgs(prefix, a);
+    }
+    public String join(String prefix, String ... a) {
+        return stringifyArgs(prefix, a);
+    }
+
+    public String joinFloat(String prefix, float ... a) {
+        return stringifyArgs(prefix, a);
+    }
+
+    public String joinLong(String prefix, long ... a) {
+        return stringifyArgs(prefix, a);
+    }
+    public String joinShort(String prefix, short ... a) {
+        return stringifyArgs(prefix, a);
+    }
+    public String joinByte(String prefix, byte ... a) {
+        return stringifyArgs(prefix, a);
+    }
+    public String joinChar(String prefix, char ... a) {
+        return stringifyArgs(prefix, a);
+    }
+    public String joinBoolean(String prefix, boolean ... a) {
+        return stringifyArgs(prefix, a);
+    }
+    public String joinObjects(String prefix, Object ... a) {
+        return stringifyArgs(prefix, a);
+    }
+
+    static String stringifyArgs(Object... args) {
+        StringBuilder argString = new StringBuilder();
+        for (int i = 0; i < args.length; i++) {
+            if (i > 0) {
+                argString.append(",");
+            }
+            Object arg = args[i];
+            if (arg != null) {
+                Class<?> argClass = arg.getClass();
+                argString.append(argClass.getSimpleName());
+                argString.append('(');
+                if (argClass.isArray()) {
+                    stringifyArray(arg, argString);
+                } else {
+                    stringifyObject(arg, argString);
+                }
+                argString.append(')');
+            } else {
+                argString.append("null");
+            }
+        }
+        return argString.toString();
+    }
+
+    private static void stringifyObject(Object arg, StringBuilder argString) {
+        argString.append(String.valueOf(arg));
+    }
+
+    private static void stringifyArray(Object arg, StringBuilder argString) {
+        boolean primitive = arg.getClass().getComponentType().isPrimitive();
+        int length = Array.getLength(arg);
+        for (int i = 0; i < length; i++) {
+            Object item = Array.get(arg, i);
+            if (i > 0) {
+                argString.append(",");
+            }
+            if (primitive) {
+                argString.append(String.valueOf(item));
+            } else {
+                argString.append(stringifyArgs(item));
+            }
+        }
+    }
+
+
+}

--- a/src/test/python/jpy_translation_test.py
+++ b/src/test/python/jpy_translation_test.py
@@ -1,0 +1,41 @@
+import unittest
+
+import jpyutil
+
+jpyutil.init_jvm(jvm_maxmem='512M', jvm_classpath=['target/test-classes'])
+import jpy
+
+class DummyWrapper:
+	def __init__(self, theThing):
+		self.theThing = theThing
+
+	def getValue(self):
+		return 2 * self.theThing.getValue()
+
+def make_wrapper(type, thing):
+	return DummyWrapper(thing)
+     
+
+class TestTypeTranslation(unittest.TestCase):
+    def setUp(self):
+        self.Fixture = jpy.get_type('org.jpy.fixtures.TypeTranslationTestFixture')
+        self.assertIsNotNone(self.Fixture)
+
+    def test_Translation(self):
+        fixture = self.Fixture()
+	thing = fixture.makeThing(7)
+        self.assertEqual(thing.getValue(), 7)
+	self.assertEquals(repr(type(thing)), "<type 'org.jpy.fixtures.Thing'>")
+
+        jpy.type_translations['org.jpy.fixtures.Thing'] = make_wrapper
+	thing = fixture.makeThing(8)
+        self.assertEqual(thing.getValue(), 16)
+        self.assertEqual(type(thing), type(DummyWrapper(None)))
+
+        jpy.type_translations['org.jpy.fixtures.Thing'] = None
+        self.assertEqual(fixture.makeThing(9).getValue(), 9)
+
+
+if __name__ == '__main__':
+    print('\nRunning ' + __file__)
+    unittest.main()


### PR DESCRIPTION
You may pass in either an array (as in the past) or individual Python arguments,
the match for a varargs method call is the minimum match for each of the
arguments.  Zero length arrays (i.e. no arguments) are also permitted with a
match value of 10.

Additionally, a jpy.type_translations dictionary is available with allows you to
easily wrap or modify all created objects of a particular java type.