### PR TITLE
Move StopIteration.java to its correct directory for its package name

### DIFF
--- a/src/main/java/org/jpy/StopIteration.java
+++ b/src/main/java/org/jpy/StopIteration.java
@@ -19,8 +19,8 @@
 package org.jpy;
 
 /**
-  * Translation of Python StopIteration so that they can be programmatically detected from Java.
-  */
+ * Translation of Python StopIteration so that they can be programmatically detected from Java.
+ */
 public class StopIteration extends RuntimeException {
     StopIteration(String message) {
         super(message);


### PR DESCRIPTION
The `StopIteration` class contains the `package org.jpy;` statement, but the `StopIteration.java` file is wrongly located in the `org/jpy/annotation` directory. Likely the package declaration is correct and the file location is wrong since this class is not an annotation. Furthermore the `org.jpy` package name is consistent with the call to `JType_GetTypeForName(jenv, "org.jpy.StopIteration", JNI_FALSE)` in `src/main/c/jpy_module.c`
