### PR TITLE
Explicit null checks for avoiding JVM crash.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@ jpy Changelog
 Version 0.9
 ===========
 
-This version includes a number of contributions from supportive GitHub users. Thanks to all of you! 
+This version includes a number of contributions from supportive GitHub users. Thanks to all of you!
 
 Fixes
 -----
@@ -14,17 +14,18 @@ Fixes
 * Fixed problem where default methods on Java 8 Interfaces were not found (issue #102). Fix by Charles P. Wright.
 * Fixed error caused by missing `sys.argv` in Python when called from Java (issue #81). Fix by Dave Voutila.
 * Fixed problem where calling jpy.get_type() too many times causes a memory access error (issue #74). Fix by Dave Voutila.
-* Fixed a corruption when retrieving long values (#72). Fix by chipkent. 
+* Fixed a corruption when retrieving long values (#72). Fix by chipkent.
 * Fixed fatal error when stopping python session (issue #70, #77). Fix by Dave Voutila.
+# Explicit null checks for avoiding JVM crash (issue #126). Fix by Geomatys.
 
 Improvements
 ------------
 
 * Can now use pip to install Python `jpy` package directly from GitHub (#83).
-  This works for Linux and OS X where C compilers are available by default 
-  and should work on Windows with Visual Studio 15 installed. 
-  Contribution by Dave Voutila. 
-* Java `PyObject` is now serializable. Contribution by Mario Briggs. 
+  This works for Linux and OS X where C compilers are available by default
+  and should work on Windows with Visual Studio 15 installed.
+  Contribution by Dave Voutila.
+* Java `PyObject` is now serializable. Contribution by Mario Briggs.
 * Improved Varargs method matching.  You may pass in either an array (as in the
   past) or individual Python arguments, the match for a varargs method call is
   the minimum match for each of the arguments. Zero length arrays (i.e. no

--- a/src/main/java/org/jpy/PyModule.java
+++ b/src/main/java/org/jpy/PyModule.java
@@ -16,6 +16,7 @@
 
 package org.jpy;
 
+import java.util.Objects;
 import static org.jpy.PyLib.assertPythonRuns;
 
 /**
@@ -89,6 +90,7 @@ public class PyModule extends PyObject {
      */
     public static PyModule importModule(String name) {
         assertPythonRuns();
+        Objects.requireNonNull(name, "name must not be null");
         long pointer = PyLib.importModule(name);
         return pointer != 0 ? new PyModule(name, pointer) : null;
     }
@@ -102,6 +104,7 @@ public class PyModule extends PyObject {
      * @since 0.8
      */
     public static PyObject extendSysPath(String modulePath, boolean prepend) {
+        Objects.requireNonNull(modulePath, "path must not be null");
         PyModule sys = importModule("sys");
         PyObject sysPath = sys.getAttribute("path");
         if (prepend) {
@@ -121,8 +124,10 @@ public class PyModule extends PyObject {
      * @param <T>  The interface name.
      * @return A (proxy) instance implementing the given interface.
      */
+    @Override
     public <T> T createProxy(Class<T> type) {
         assertPythonRuns();
+        Objects.requireNonNull(type, "type must not be null");
         return (T) createProxy(PyLib.CallableKind.FUNCTION, type);
     }
 }

--- a/src/main/java/org/jpy/PyObject.java
+++ b/src/main/java/org/jpy/PyObject.java
@@ -22,7 +22,6 @@ package org.jpy;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Proxy;
 import java.util.List;
-import java.util.Map;
 import java.io.FileNotFoundException;
 import java.util.Objects;
 
@@ -79,17 +78,13 @@ public class PyObject implements java.io.Serializable {
      *
      * @param code    The Python source code.
      * @param mode    The execution mode.
-     * @param globals The global variables to be set.
-     * @param locals  The locals variables to be set.
+     * @param globals The global variables to be set, or {@code null}.
+     * @param locals  The locals variables to be set, or {@code null}.
      * @return The result of executing the code as a Python object.
      */
     public static PyObject executeCode(String code, PyInputMode mode, Object globals, Object locals) {
-        if (code == null) {
-            throw new NullPointerException("code must not be null");
-        }
-        if (mode == null) {
-            throw new NullPointerException("mode must not be null");
-        }
+        Objects.requireNonNull(code, "code must not be null");
+        Objects.requireNonNull(mode, "mode must not be null");
         return new PyObject(PyLib.executeCode(code, mode.value(), globals, locals));
     }
 
@@ -102,18 +97,14 @@ public class PyObject implements java.io.Serializable {
      *
      * @param script    The Python source script.
      * @param mode    The execution mode.
-     * @param globals The global variables to be set.
-     * @param locals  The locals variables to be set.
+     * @param globals The global variables to be set, or {@code null}.
+     * @param locals  The locals variables to be set, or {@code null}.
      * @return The result of executing the script as a Python object.
      * @throws FileNotFoundException if the script file is not found
      */
     public static PyObject executeScript(String script, PyInputMode mode, Object globals, Object locals) throws FileNotFoundException {
-        if (script == null) {
-            throw new NullPointerException("script must not be null");
-        }
-        if (mode == null) {
-            throw new NullPointerException("mode must not be null");
-        }
+        Objects.requireNonNull(script, "script must not be null");
+        Objects.requireNonNull(mode, "mode must not be null");
         return new PyObject(PyLib.executeScript(script, mode.value(), globals, locals));
     }
 
@@ -272,6 +263,7 @@ public class PyObject implements java.io.Serializable {
      */
     public <T> T[] getObjectArrayValue(Class<? extends T> itemType) {
         assertPythonRuns();
+        Objects.requireNonNull(itemType, "itemType must not be null");
         return PyLib.getObjectArrayValue(getPointer(), itemType);
     }
 
@@ -286,6 +278,7 @@ public class PyObject implements java.io.Serializable {
      */
     public PyObject getAttribute(String name) {
         assertPythonRuns();
+        Objects.requireNonNull(name, "name must not be null");
         long pointer = PyLib.getAttributeObject(getPointer(), name);
         return pointer != 0 ? new PyObject(pointer) : null;
     }
@@ -298,12 +291,13 @@ public class PyObject implements java.io.Serializable {
      * If the Python value is a wrapped Java object, it will be unwrapped.
      *
      * @param name      A name of the Python attribute.
-     * @param valueType The type of the value or {@code null}, if unknown
+     * @param valueType The type of the value or {@code null}, if unknown.
      * @param <T>       The expected value type name.
      * @return The Python attribute value as Java object.
      */
     public <T> T getAttribute(String name, Class<? extends T> valueType) {
         assertPythonRuns();
+        Objects.requireNonNull(name, "name must not be null");
         return PyLib.getAttributeValue(getPointer(), name, valueType);
     }
 
@@ -314,11 +308,12 @@ public class PyObject implements java.io.Serializable {
      * If the Java {@code value} is a wrapped Python object of type {@link PyObject}, it will be unwrapped.
      *
      * @param name  A name of the Python attribute.
-     * @param value The new attribute value as Java object.
+     * @param value The new attribute value as Java object. May be {@code null}.
      * @param <T>   The value type name.
      */
     public <T> void setAttribute(String name, T value) {
         assertPythonRuns();
+        Objects.requireNonNull(name, "name must not be null");
         PyLib.setAttributeValue(getPointer(), name, value, value != null ? value.getClass() : null);
     }
 
@@ -329,6 +324,7 @@ public class PyObject implements java.io.Serializable {
      */
     public void delAttribute(String name) {
         assertPythonRuns();
+        Objects.requireNonNull(name, "name must not be null");
         PyLib.delAttribute(getPointer(), name);
     }
 
@@ -340,6 +336,7 @@ public class PyObject implements java.io.Serializable {
      */
     public boolean hasAttribute(String name) {
         assertPythonRuns();
+        Objects.requireNonNull(name, "name must not be null");
         return PyLib.hasAttribute(getPointer(), name);
     }
 
@@ -357,6 +354,7 @@ public class PyObject implements java.io.Serializable {
      */
     public <T> void setAttribute(String name, T value, Class<? extends T> valueType) {
         assertPythonRuns();
+        Objects.requireNonNull(name, "name must not be null");
         PyLib.setAttributeValue(getPointer(), name, value, valueType);
     }
 
@@ -372,7 +370,7 @@ public class PyObject implements java.io.Serializable {
      */
     public PyObject callMethod(String name, Object... args) {
         assertPythonRuns();
-        Objects.requireNonNull(name);
+        Objects.requireNonNull(name, "name must not be null");
         long pointer = PyLib.callAndReturnObject(getPointer(), true, name, args.length, args, null);
         return pointer != 0 ? new PyObject(pointer) : null;
     }
@@ -389,7 +387,7 @@ public class PyObject implements java.io.Serializable {
      */
     public PyObject call(String name, Object... args) {
         assertPythonRuns();
-        Objects.requireNonNull(name);
+        Objects.requireNonNull(name, "name must not be null");
         long pointer = PyLib.callAndReturnObject(getPointer(), false, name, args.length, args, null);
         return pointer != 0 ? new PyObject(pointer) : null;
     }
@@ -405,6 +403,7 @@ public class PyObject implements java.io.Serializable {
     public <T> T createProxy(Class<T> type) {
         assertPythonRuns();
         //noinspection unchecked
+        Objects.requireNonNull(type, "type must not be null");
         return (T) createProxy(PyLib.CallableKind.METHOD, type);
     }
 


### PR DESCRIPTION
Reference: https://github.com/bcdev/jpy/pull/126

Changes in this commit:

* Use of `Objects.requireNonNull` is some places were passing a null argument causes a JVM crash.
* Replace some `if (foo == null) throws NullPointerException` statements by `Objects.requireNonNull`.
* Update Javadoc by saying when an argument can be null.
* Opportunistic removal of an unused import statement and trailing spaces.
