### PR TITLE
make constants get into Python correctly

### DIFF
--- a/src/main/c/jpy_jtype.c
+++ b/src/main/c/jpy_jtype.c
@@ -284,23 +284,23 @@ PyObject* JType_ConvertJavaToPythonObject(JNIEnv* jenv, JPy_JType* type, jobject
 
     if (type->componentType == NULL) {
         // Scalar type, not an array, try to convert to Python equivalent
-        if (type == JPy_JBooleanObj) {
+        if (type == JPy_JBooleanObj || type == JPy_JBoolean) {
             jboolean value = (*jenv)->CallBooleanMethod(jenv, objectRef, JPy_Boolean_BooleanValue_MID);
             JPy_ON_JAVA_EXCEPTION_RETURN(NULL);
             return JPy_FROM_JBOOLEAN(value);
-        } else if (type == JPy_JCharacterObj) {
+        } else if (type == JPy_JCharacterObj || type == JPy_JChar) {
             jchar value = (*jenv)->CallCharMethod(jenv, objectRef, JPy_Character_CharValue_MID);
             JPy_ON_JAVA_EXCEPTION_RETURN(NULL);
             return JPy_FROM_JCHAR(value);
-        } else if (type == JPy_JByteObj || type == JPy_JShortObj || type == JPy_JIntegerObj) {
+        } else if (type == JPy_JByteObj || type == JPy_JShortObj || type == JPy_JIntegerObj || type == JPy_JShort || type == JPy_JInt) {
             jint value = (*jenv)->CallIntMethod(jenv, objectRef, JPy_Number_IntValue_MID);
             JPy_ON_JAVA_EXCEPTION_RETURN(NULL);
             return JPy_FROM_JINT(value);
-        } else if (type == JPy_JLongObj) {
+        } else if (type == JPy_JLongObj || type == JPy_JLong) {
             jlong value = (*jenv)->CallLongMethod(jenv, objectRef, JPy_Number_LongValue_MID);
             JPy_ON_JAVA_EXCEPTION_RETURN(NULL);
             return JPy_FROM_JLONG(value);
-        } else if (type == JPy_JFloatObj || type == JPy_JDoubleObj) {
+        } else if (type == JPy_JFloatObj || type == JPy_JDoubleObj || type == JPy_JFloat || type == JPy_JDouble) {
             jdouble value = (*jenv)->CallDoubleMethod(jenv, objectRef, JPy_Number_DoubleValue_MID);
             JPy_ON_JAVA_EXCEPTION_RETURN(NULL);
             return JPy_FROM_JDOUBLE(value);

--- a/src/main/java/org/jpy/PyDictWrapper.java
+++ b/src/main/java/org/jpy/PyDictWrapper.java
@@ -168,12 +168,13 @@ public class PyDictWrapper implements Map<PyObject, PyObject> {
         @Override
         public Iterator<Entry<PyObject, PyObject>> iterator() {
             return new Iterator<Entry<PyObject, PyObject>>() {
+                PyModule builtins = PyModule.getBuiltins();
                 PyObject it = pyObject.callMethod("__iter__");
                 PyObject next = prepareNext();
 
                 private PyObject prepareNext() {
                     try {
-                        return next = it.callMethod("next");
+                        return next = builtins.call("next", it);
                     } catch (StopIteration e) {
                         return next = null;
                     }

--- a/src/test/java/org/jpy/PyObjectTest.java
+++ b/src/test/java/org/jpy/PyObjectTest.java
@@ -279,6 +279,10 @@ public class PyObjectTest {
         assertEquals("computeTile-100,200", result);
         result = processor.computeTile(200, 200, new float[100 * 100]);
         assertEquals("computeTile-200,200", result);
+        processor.setVal(1234);
+        int val = processor.getVal();
+        assertEquals(val, 1234);
+        assertEquals(true, processor.check1234());
         result = processor.dispose();
         assertEquals("dispose", result);
     }

--- a/src/test/java/org/jpy/fixtures/Processor.java
+++ b/src/test/java/org/jpy/fixtures/Processor.java
@@ -27,4 +27,10 @@ public interface Processor {
     String computeTile(int w, int h, float[] data);
 
     String dispose();
+    
+    void setVal(int n);
+    
+    int getVal();
+    
+    boolean check1234();
 }

--- a/src/test/python/fixtures/proc_class.py
+++ b/src/test/python/fixtures/proc_class.py
@@ -19,5 +19,12 @@ class Processor:
         for i in range(10000):
             l.reverse()
 
+    def setVal(self, val):
+        self._val = val
+        
+    def getVal(self):
+        return self._val
 
-
+    def check1234(self):
+        return self._val == 1234
+    

--- a/src/test/python/fixtures/proc_module.py
+++ b/src/test/python/fixtures/proc_module.py
@@ -15,6 +15,15 @@ def spend_some_time():
     for i in range(10000):
         l.reverse()
 
+_module_val = None
+def setVal(val):
+    global _module_val
+    _module_val = val
+    
+def getVal():
+    global _module_val
+    return _module_val
 
-
-
+def check1234():
+    global _module_val
+    return _module_val == 1234


### PR DESCRIPTION
This fixes issue #140 

In order for the maven tests to pass, it includes the code from #137 
