### PR TITLE
Docs for setPythonHome

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -90,6 +90,13 @@ All the parameters can be passed directly to the JVM either as Java system prope
 
 Such property file is also written for each build and is found in ``build/lib-<os-platform>-<python-version>/jpyconfig.properties``.
 
+Setting PYTHONHOME
+------------------
+
+If the environment variable ``PYTHONHOME`` is not set when you call Python from Java, you may get an error about
+file system encodings not being found. It is possible to set the location of Python from your
+Java program.  Use ``PyLib.setPythonHome(pathToPythonHome)`` to do that, where ``pathToPythonHome`` is a ``String`` that 
+contains the location of the Python installation.
 
 ========================
 Build for Linux / Darwin


### PR DESCRIPTION
Ref #144 

Added documentation in install section about setting PYTHONHOME from Java.

NOTE:  I'm now wondering if this should be done automatically from the settings in `jpyconfig.properties` of the `jpy.pythonPrefix` parameter.

Also, is it worth bumping the version number to 0.9.1 for these latest changes I submitted?
