### PR TITLE
Improve proxying

### DIFF
--- a/src/main/c/jni/org_jpy_PyLib.h
+++ b/src/main/c/jni/org_jpy_PyLib.h
@@ -113,6 +113,14 @@ JNIEXPORT jint JNICALL Java_org_jpy_PyLib_getIntValue
 
 /*
  * Class:     org_jpy_PyLib
+ * Method:    getLongValue
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_org_jpy_PyLib_getLongValue
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_jpy_PyLib
  * Method:    getBooleanValue
  * Signature: (J)Z
  */
@@ -246,6 +254,22 @@ JNIEXPORT jstring JNICALL Java_org_jpy_PyLib_str
  */
 JNIEXPORT jstring JNICALL Java_org_jpy_PyLib_repr
   (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_jpy_PyLib
+ * Method:    hash
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_org_jpy_PyLib_hash
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     org_jpy_PyLib
+ * Method:    eq
+ * Signature: (JLjava/lang/Object;)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_jpy_PyLib_eq
+  (JNIEnv *, jclass, jlong, jobject);
 
 /*
  * Class:     org_jpy_PyLib

--- a/src/main/c/jpy_module.h
+++ b/src/main/c/jpy_module.h
@@ -212,6 +212,7 @@ extern jclass JPy_Void_JClass;
 
 extern jclass JPy_PyObject_JClass;
 extern jmethodID JPy_PyObject_GetPointer_MID;
+extern jmethodID JPy_PyObject_UnwrapProxy_SMID;
 extern jmethodID JPy_PyObject_Init_MID;
 
 extern jclass JPy_PyDictWrapper_JClass;

--- a/src/main/java/org/jpy/PyLib.java
+++ b/src/main/java/org/jpy/PyLib.java
@@ -260,6 +260,8 @@ public class PyLib {
 
     static native int getIntValue(long pointer);
 
+    static native int getLongValue(long pointer);
+
     static native boolean getBooleanValue(long pointer);
 
     static native double getDoubleValue(long pointer);
@@ -284,6 +286,10 @@ public class PyLib {
     static native String str(long pointer);
 
     static native String repr(long pointer);
+
+    static native long hash(long pointer);
+
+    static native boolean eq(long pointer1, Object other);
 
     static native PyObject newDict();
 

--- a/src/main/java/org/jpy/PyObject.java
+++ b/src/main/java/org/jpy/PyObject.java
@@ -431,6 +431,24 @@ public class PyObject {
     }
 
     /**
+     * Unwraps the original Python object used to create {@code object}. The inverse of
+     * {@link #createProxy(Class)}.
+     *
+     * @param object The object that may be a proxy.
+     * @return The Python object, or null if the object is not a proxy.
+     */
+    public static PyObject unwrapProxy(Object object) {
+        if (!Proxy.isProxyClass(object.getClass())) {
+            return null;
+        }
+        InvocationHandler handler = Proxy.getInvocationHandler(object);
+        if (!(handler instanceof PyProxyHandler)) {
+            return null;
+        }
+        return ((PyProxyHandler)handler).getPyObject();
+    }
+
+    /**
      * Gets the python string representation of this object.
      *
      * @return A string representation of the object.

--- a/src/main/java/org/jpy/PyObject.java
+++ b/src/main/java/org/jpy/PyObject.java
@@ -139,6 +139,14 @@ public class PyObject {
     }
 
     /**
+     * @return This Python object as a Java {@code long} value.
+     */
+    public long getLongValue() {
+        assertPythonRuns();
+        return PyLib.getLongValue(getPointer());
+    }
+
+    /**
      * @return This Python object as a Java {@code boolean} value.
      */
     public boolean getBooleanValue() {
@@ -430,7 +438,7 @@ public class PyObject {
      */
     @Override
     public final String toString() {
-	    return PyLib.str(pointer);
+	    return str();
     }
 
     /**
@@ -441,6 +449,26 @@ public class PyObject {
      */
     public final String repr() {
 	    return PyLib.repr(pointer);
+    }
+
+    /**
+     * Runs the python str function on this object.
+     * @return The String representation of this object.
+     */
+    public final String str() {
+        return PyLib.str(pointer);
+    }
+
+    /**
+     * Runs the python hash function on this object.
+     * @return The hash.
+     */
+    public final long hash() {
+        return PyLib.hash(pointer);
+    }
+
+    public final boolean eq(Object other) {
+        return PyLib.eq(pointer, other);
     }
 
     /**

--- a/src/test/java/org/jpy/PyObjectTest.java
+++ b/src/test/java/org/jpy/PyObjectTest.java
@@ -260,7 +260,21 @@ public class PyObjectTest {
         testCallProxyMultiThreaded(procObj);
         // PyLib.Diag.setFlags(PyLib.Diag.F_OFF);
     }
-    
+
+    @Test
+    public void testUnwrapProxy() {
+        PyModule procModule = PyModule.importModule("proc_class");
+        PyObject procObj = procModule.call("Processor");
+        Processor proxy = procObj.createProxy(Processor.class);
+        PyObject unwrapped = PyObject.unwrapProxy(proxy);
+        assertSame(procObj, unwrapped);
+    }
+
+    @Test
+    public void testUnwrapProxyNotAProxy() {
+        assertNull(PyObject.unwrapProxy(this));
+    }
+
     static void testCallProxySingleThreaded(PyObject procObject) {
         // Cast the Python object to a Java object of type 'Processor'
         Processor processor = procObject.createProxy(Processor.class);

--- a/src/test/java/org/jpy/PyProxyTest.java
+++ b/src/test/java/org/jpy/PyProxyTest.java
@@ -1,0 +1,290 @@
+package org.jpy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.File;
+import java.util.regex.Pattern;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PyProxyTest {
+  private PyModule MODULE;
+
+  @Before
+  public void setUp() throws Exception {
+    PyLib.startPython(new File("src/test/python/fixtures").getCanonicalPath());
+    assertTrue(PyLib.isPythonRunning());
+
+    MODULE = PyModule.importModule("proxy_test_classes");
+    //PyLib.Diag.setFlags(PyLib.Diag.F_ALL);
+  }
+
+  @After
+  public void tearDown() {
+    //PyLib.Diag.setFlags(Diag.F_OFF);
+    PyLib.stopPython();
+  }
+
+  interface HasStr {
+
+  }
+
+  interface DoesNotHaveStr {
+
+  }
+
+  interface HasToStringWithArg {
+    String toString(Object arg);
+  }
+
+  interface HasHashCodeWithArg {
+    int hashCode(Object arg);
+  }
+
+  interface HasHashNegativeOne {
+
+  }
+
+  interface HasEqualsWithoutArg {
+    boolean equals();
+  }
+
+  interface EqAlwaysTrue {
+
+  }
+
+  interface EqAlwaysFalse {
+
+  }
+
+  interface ProxyAsArgument {
+    boolean self_is_other(ProxyAsArgument other);
+  }
+
+  interface ThrowsException {
+
+  }
+
+  interface NonBooleanEq {
+
+  }
+
+  @Test
+  public void hasStrToString() {
+    PyObject pyObj = MODULE.call("HasStr");
+    HasStr proxy = pyObj.createProxy(HasStr.class);
+
+    assertEquals("This is my __str__ method", pyObj.toString());
+    assertEquals("This is my __str__ method", proxy.toString());
+  }
+
+  @Test
+  public void doesNotHaveStrToString() {
+    PyObject pyObj = MODULE.call("DoesNotHaveStr");
+    DoesNotHaveStr proxy = pyObj.createProxy(DoesNotHaveStr.class);
+
+    // python2 uses instance, python3 uses object
+    Pattern pattern = Pattern
+        .compile("^<proxy_test_classes.DoesNotHaveStr (instance|object) at 0x[0-9a-f]+>$");
+
+    String pyObjToString = pyObj.toString();
+    String proxyToString = proxy.toString();
+
+    assertTrue(pattern.matcher(pyObjToString).matches());
+    assertTrue(pattern.matcher(proxyToString).matches());
+    assertEquals(pyObjToString, proxyToString);
+  }
+
+  @Test
+  public void hasToStringWithArg() {
+    PyObject pyObj = MODULE.call("HasToStringWithArg");
+
+    HasToStringWithArg proxy = pyObj.createProxy(HasToStringWithArg.class);
+
+    assertEquals("weird", proxy.toString(this));
+    assertNotEquals("weird", proxy.toString());
+  }
+
+  @Test
+  public void hasHashCodeWithArg() {
+    PyObject pyObj = MODULE.call("HasHashCodeWithArg");
+
+    HasHashCodeWithArg proxy = pyObj.createProxy(HasHashCodeWithArg.class);
+
+    assertEquals(0, proxy.hashCode(this));
+    assertEquals(1, proxy.hashCode());
+  }
+
+  @Test
+  public void hasHashCodeNegativeOne() {
+    /*
+    >>> class Hash:
+    ...     def __hash__(self):
+    ...             return -1
+    ...
+    >>> h = Hash()
+    >>> hash(h)
+    -2
+    >>> h.__hash__()
+    -1
+     */
+    PyObject pyObj = MODULE.call("HasHashNegativeOne");
+
+    // Python reserves -1 for an error status on PyObject_Hash. When __hash__ returns -1,
+    // python changes it to -2.
+    assertEquals(pyObj.hash(), -2);
+
+    HasHashNegativeOne proxy = pyObj.createProxy(HasHashNegativeOne.class);
+    assertEquals(proxy.hashCode(), Long.hashCode(-2L));
+  }
+
+  @Test
+  public void hasEqualsWithoutArg() {
+    PyObject pyObj = MODULE.call("HasEqualsWithoutArg");
+
+    HasEqualsWithoutArg proxy = pyObj.createProxy(HasEqualsWithoutArg.class);
+
+    assertTrue(proxy.equals());
+    assertEquals(proxy, proxy);
+  }
+
+  @Test
+  public void eqAlwaysTrue() {
+    PyObject pyObj1 = MODULE.call("EqAlwaysTrue");
+    EqAlwaysTrue proxy1 = pyObj1.createProxy(EqAlwaysTrue.class);
+
+    PyObject pyObj2 = MODULE.call("EqAlwaysTrue");
+    EqAlwaysTrue proxy2 = pyObj2.createProxy(EqAlwaysTrue.class);
+
+    assertEquals(proxy1, proxy1);
+    assertEquals(proxy2, proxy2);
+
+    assertEquals(proxy1, proxy2);
+    assertEquals(proxy2, proxy1);
+
+    // note: can't call assertEquals, b/c that does null checks
+    assertTrue(proxy1.equals(null));
+    assertTrue(proxy2.equals(null));
+  }
+
+  @Test
+  public void eqAlwaysFalse() {
+    PyObject pyObj1 = MODULE.call("EqAlwaysFalse");
+    EqAlwaysFalse proxy1 = pyObj1.createProxy(EqAlwaysFalse.class);
+
+    PyObject pyObj2 = MODULE.call("EqAlwaysFalse");
+    EqAlwaysFalse proxy2 = pyObj2.createProxy(EqAlwaysFalse.class);
+
+    assertNotEquals(proxy1, proxy1);
+    assertNotEquals(proxy2, proxy2);
+
+    assertNotEquals(proxy1, proxy2);
+    assertNotEquals(proxy2, proxy1);
+
+    // note: can't call assertEquals, b/c that does null checks
+    assertFalse(proxy1.equals(null));
+    assertFalse(proxy2.equals(null));
+  }
+
+  @Test
+  public void eqAlwaysTrueVsFalse() {
+    /*
+    >>> class EqAlwaysTrue:
+    ...     def __eq__(self, other):
+    ...             return True
+    ...
+    >>> class EqAlwaysFalse:
+    ...     def __eq__(self, other):
+    ...             return False
+    ...
+    >>> a = A()
+    >>> b = B()
+    >>> a == b
+    True
+    >>> b == a
+    False
+     */
+
+    PyObject pyObj1 = MODULE.call("EqAlwaysTrue");
+    EqAlwaysTrue alwaysTrue = pyObj1.createProxy(EqAlwaysTrue.class);
+
+    PyObject pyObj2 = MODULE.call("EqAlwaysFalse");
+    EqAlwaysFalse alwaysFalse = pyObj2.createProxy(EqAlwaysFalse.class);
+
+    assertEquals(alwaysTrue, alwaysFalse);
+    assertNotEquals(alwaysFalse, alwaysTrue);
+  }
+
+  @Test
+  public void canUnwrapProxyPassedAsArgument() {
+    PyObject pyObject1 = MODULE.call("ProxyAsArgument");
+    ProxyAsArgument proxy1 = pyObject1.createProxy(ProxyAsArgument.class);
+
+    PyObject pyObject2 = MODULE.call("ProxyAsArgument");
+    ProxyAsArgument proxy2 = pyObject2.createProxy(ProxyAsArgument.class);
+
+    assertTrue(proxy1.self_is_other(proxy1));
+    assertTrue(proxy2.self_is_other(proxy2));
+
+    assertFalse(proxy1.self_is_other(proxy2));
+    assertFalse(proxy2.self_is_other(proxy1));
+
+    assertEquals(proxy1, proxy1);
+    assertEquals(proxy2, proxy2);
+
+    assertNotEquals(proxy1, proxy2);
+    assertNotEquals(proxy2, proxy1);
+  }
+
+  @Test
+  public void equalsException() {
+    PyObject pyObject = MODULE.call("ThrowsException");
+    ThrowsException throwsException = pyObject
+        .createProxy(ThrowsException.class);
+    try {
+      throwsException.equals(throwsException);
+      fail("Expected an RuntimeException to be thrown");
+    } catch (RuntimeException e) {
+      //throw e;
+      //assertTrue(e.getMessage().contains("Value: this __eq__ always raises Exception"));
+    }
+  }
+
+  @Test
+  public void hashCodeException() {
+    PyObject pyObject = MODULE.call("ThrowsException");
+    ThrowsException throwsException = pyObject
+        .createProxy(ThrowsException.class);
+    try {
+      throwsException.hashCode();
+      fail("Expected an RuntimeException to be thrown");
+    } catch (RuntimeException e) {
+      //assertTrue(e.getMessage().contains("Value: this __hash__ always raises Exception"));
+    }
+  }
+
+  @Test
+  public void toStringException() {
+    PyObject pyObject = MODULE.call("ThrowsException");
+    ThrowsException throwsException = pyObject
+        .createProxy(ThrowsException.class);
+    try {
+      throwsException.toString();
+      fail("Expected an RuntimeException to be thrown");
+    } catch (RuntimeException e) {
+      //assertTrue(e.getMessage().contains("Value: this __str__ always raises Exception"));
+    }
+  }
+
+  @Test
+  public void nonBooleanEquals() {
+    PyObject pyObject = MODULE.call("NonBooleanEq");
+    NonBooleanEq proxy = pyObject.createProxy(NonBooleanEq.class);
+    assertEquals(proxy, proxy);
+  }
+}

--- a/src/test/python/fixtures/proxy_test_classes.py
+++ b/src/test/python/fixtures/proxy_test_classes.py
@@ -1,0 +1,58 @@
+class HasStr:
+    def __str__(self):
+        return 'This is my __str__ method'
+
+class DoesNotHaveStr:
+    def __init__(self):
+        pass
+
+class HasToStringWithArg:
+    def toString(self, arg):
+        return 'weird'
+
+class HasHashCodeWithArg:
+    def hashCode(self, arg):
+        return 0
+
+    def __hash__(self):
+        return 1
+
+class HasHashNegativeOne:
+    def __hash__(self):
+        return -1
+
+class HasEqualsWithoutArg:
+    def equals(self):
+        return True
+
+class EqAlwaysFalse:
+    def __eq__(self, other):
+        return False
+
+class EqAlwaysTrue:
+    def __eq__(self, other):
+        return True
+
+class NoEqDefined:
+    def __init__(self):
+        pass
+
+class ProxyAsArgument:
+    def self_is_other(self, other):
+        return self is other
+
+class ThrowsException:
+    def __hash__(self):
+        raise Exception('this __hash__ always raises Exception')
+
+    def __str__(self):
+        raise Exception('this __str__ always raises Exception')
+
+    def __eq__(self, other):
+        raise Exception('this __eq__ always raises Exception')
+
+class NonBooleanEq:
+    def __eq__(self, other):
+        if self is other:
+            return 1
+        return 0

--- a/src/test/python/fixtures/special_methods.py
+++ b/src/test/python/fixtures/special_methods.py
@@ -1,0 +1,50 @@
+class Simple:
+    def __init__(self, x):
+        self.x = x
+
+    def __hash__(self):
+        return hash(self.x)
+
+    def __str__(self):
+        return str(self.x)
+
+    def __eq__(self, other):
+        return self.x == other
+
+class ThrowsException:
+    def __hash__(self):
+        raise Exception('this __hash__ always raises Exception')
+
+    def __str__(self):
+        raise Exception('this __str__ always raises Exception')
+
+    def __eq__(self, other):
+        raise Exception('this __eq__ always raises Exception')
+
+# __eq__ *can* return non boolean values
+class NonBooleanEq:
+    def __eq__(self, other):
+        if self is other:
+            return 1
+        return 0
+
+# __str__ should *not* return non string values
+class NonStringStr:
+    def __str__(self):
+        return 1
+
+class NoMethodsDefined:
+    def __init__(self):
+        pass
+
+class EqAlwaysFalse:
+    def __eq__(self, other):
+        return False
+
+class EqAlwaysTrue:
+    def __eq__(self, other):
+        return True
+
+class HashNegativeOne:
+    def __hash__(self):
+        return -1

--- a/src/test/python/jpy_exception_test.py
+++ b/src/test/python/jpy_exception_test.py
@@ -54,42 +54,42 @@ class TestExceptions(unittest.TestCase):
         self.assertEqual(str(e.exception), 'java.io.IOException: Evil!')
 
     # Checking the exceptions for differences (e.g. in white space) can be a huge pain, this helps)
-    def hexdump(self, s):
-        for i in xrange(0, len(s), 32):
-            sl = s[i:min(i + 32, len(s))]
-	    fsl = map(lambda x : x if (x in string.printable and not x in "\n\t\r") else ".", sl)
-            print "%08d %s %s %s" % (i, " ".join("{:02x}".format(ord(c)) for c in sl), ("   ".join(map(lambda x : "", xrange(32 - len(sl))))), sl)
+    #def hexdump(self, s):
+    #    for i in xrange(0, len(s), 32):
+    #        sl = s[i:min(i + 32, len(s))]
+    #        fsl = map(lambda x : x if (x in string.printable and not x in "\n\t\r") else ".", sl)
+    #        print "%08d %s %s %s" % (i, " ".join("{:02x}".format(ord(c)) for c in sl), ("   ".join(map(lambda x : "", xrange(32 - len(sl))))), sl)
 
     def test_VerboseException(self):
         fixture = self.Fixture()
 
-	jpy.VerboseExceptions.enabled = True
+        jpy.VerboseExceptions.enabled = True
 
-	self.assertEqual(fixture.throwNpeIfArgIsNull("123456"), 6)
+        self.assertEqual(fixture.throwNpeIfArgIsNull("123456"), 6)
 
-	with self.assertRaises(RuntimeError) as e:
+        with self.assertRaises(RuntimeError) as e:
             fixture.throwNpeIfArgIsNullNested(None)
-	actualMessage = str(e.exception)
-	expectedMessage = "java.lang.RuntimeException: Nested exception\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested(ExceptionTestFixture.java:43)\ncaused by java.lang.NullPointerException\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNull(ExceptionTestFixture.java:32)\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested(ExceptionTestFixture.java:41)\n"
+        actualMessage = str(e.exception)
+        expectedMessage = "java.lang.RuntimeException: Nested exception\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested(ExceptionTestFixture.java:43)\ncaused by java.lang.NullPointerException\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNull(ExceptionTestFixture.java:32)\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested(ExceptionTestFixture.java:41)\n"
 
-	#self.hexdump(actualMessage)
-	#self.hexdump(expectedMessage)
-	#print [i for i in xrange(min(len(expectedMessage), len(actualMessage))) if actualMessage[i] != expectedMessage[i]]
+        #self.hexdump(actualMessage)
+        #self.hexdump(expectedMessage)
+        #print [i for i in xrange(min(len(expectedMessage), len(actualMessage))) if actualMessage[i] != expectedMessage[i]]
 
-	self.assertEquals(actualMessage, expectedMessage)
+        self.assertEquals(actualMessage, expectedMessage)
 
-	with self.assertRaises(RuntimeError) as e:
+        with self.assertRaises(RuntimeError) as e:
             fixture.throwNpeIfArgIsNullNested3(None)
-	actualMessage = str(e.exception)
-	expectedMessage = "java.lang.RuntimeException: Nested exception 3\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested3(ExceptionTestFixture.java:55)\ncaused by java.lang.RuntimeException: Nested exception\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested(ExceptionTestFixture.java:43)\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested2(ExceptionTestFixture.java:48)\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested3(ExceptionTestFixture.java:53)\ncaused by java.lang.NullPointerException\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNull(ExceptionTestFixture.java:32)\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested(ExceptionTestFixture.java:41)\n\t... 2 more\n"
+        actualMessage = str(e.exception)
+        expectedMessage = "java.lang.RuntimeException: Nested exception 3\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested3(ExceptionTestFixture.java:55)\ncaused by java.lang.RuntimeException: Nested exception\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested(ExceptionTestFixture.java:43)\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested2(ExceptionTestFixture.java:48)\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested3(ExceptionTestFixture.java:53)\ncaused by java.lang.NullPointerException\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNull(ExceptionTestFixture.java:32)\n\tat org.jpy.fixtures.ExceptionTestFixture.throwNpeIfArgIsNullNested(ExceptionTestFixture.java:41)\n\t... 2 more\n"
 
-	#self.hexdump(actualMessage)
-	#self.hexdump(expectedMessage)
-	#print [i for i in xrange(min(len(expectedMessage), len(actualMessage))) if actualMessage[i] != expectedMessage[i]]
+        #self.hexdump(actualMessage)
+        #self.hexdump(expectedMessage)
+        #print [i for i in xrange(min(len(expectedMessage), len(actualMessage))) if actualMessage[i] != expectedMessage[i]]
 
-	self.assertEquals(actualMessage, expectedMessage)
+        self.assertEquals(actualMessage, expectedMessage)
 
-	jpy.VerboseExceptions.enabled = False
+        jpy.VerboseExceptions.enabled = False
 
 
 if __name__ == '__main__':

--- a/src/test/python/jpy_translation_test.py
+++ b/src/test/python/jpy_translation_test.py
@@ -7,15 +7,15 @@ jpyutil.init_jvm(jvm_maxmem='512M', jvm_classpath=['target/test-classes'])
 import jpy
 
 class DummyWrapper:
-	def __init__(self, theThing):
-		self.theThing = theThing
+    def __init__(self, theThing):
+        self.theThing = theThing
 
-	def getValue(self):
-		return 2 * self.theThing.getValue()
+    def getValue(self):
+        return 2 * self.theThing.getValue()
 
 def make_wrapper(type, thing):
-	return DummyWrapper(thing)
-     
+    return DummyWrapper(thing)
+
 
 class TestTypeTranslation(unittest.TestCase):
     def setUp(self):
@@ -24,12 +24,12 @@ class TestTypeTranslation(unittest.TestCase):
 
     def test_Translation(self):
         fixture = self.Fixture()
-	thing = fixture.makeThing(7)
+        thing = fixture.makeThing(7)
         self.assertEqual(thing.getValue(), 7)
-	self.assertEquals(repr(type(thing)), "<type 'org.jpy.fixtures.Thing'>")
+        self.assertTrue(repr(type(thing)) in ["<type 'org.jpy.fixtures.Thing'>", "<class 'org.jpy.fixtures.Thing'>"])
 
         jpy.type_translations['org.jpy.fixtures.Thing'] = make_wrapper
-	thing = fixture.makeThing(8)
+        thing = fixture.makeThing(8)
         self.assertEqual(thing.getValue(), 16)
         self.assertEqual(type(thing), type(DummyWrapper(None)))
 


### PR DESCRIPTION
Use str(), hash(), and == for proxying, as opposed to calling methods directly.  Unwrap proxied Java objects to their original PyObject.