### PR TITLE
Update jpyutil.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ## Version 0.10 (in development)
 
+* [#180] Add the ability to pass properties and options to write_config_files. These values get passed 
+  to the jvm when it is initialized.  Contribution by davidlehrian.
 * Make jpy work with Anaconda by setting environment variable 
   `PYTHONHOME` from Java 
   [#143](https://github.com/bcdev/jpy/issues/143). Contribution by Dr-Irv.  

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,9 @@
 
 ## Version 0.10 (in development)
 
-* [#180] Add the ability to pass properties and options to write_config_files. These values get passed 
-  to the jvm when it is initialized.  Contribution by davidlehrian.
+* Add the ability to pass properties and options to write_config_files. These values get passed 
+  to the jvm when it is initialized.
+  [#180](https://github.com/bcdev/jpy/pull/180#issue-513362903) Contribution by davidlehrian.
 * Make jpy work with Anaconda by setting environment variable 
   `PYTHONHOME` from Java 
   [#143](https://github.com/bcdev/jpy/issues/143). Contribution by Dr-Irv.  

--- a/jpyutil.py
+++ b/jpyutil.py
@@ -575,7 +575,7 @@ def write_config_files(out_dir='.',
                 if jvm_options is None:
                     f.write('jvm_options = []\n')
                 else:
-                    f.write('jvm_options = [''' + jvm_options + ''']\n''')
+                    f.write('jvm_options = [\'' + jvm_options + '\']\n')
             logger.info("jpy Python API configuration written to '%s'" % py_api_config_file)
         except Exception:
             logger.exception("Error while writing Python API configuration")

--- a/jpyutil.py
+++ b/jpyutil.py
@@ -531,7 +531,9 @@ def write_config_files(out_dir='.',
                        jvm_dll_file=None,
                        install_dir=None,
                        req_java_api_conf=True,
-                       req_py_api_conf=True):
+                       req_py_api_conf=True,
+                       jvm_properties=None,
+                       jvm_options=None):
     """
     Writes the jpy configuration files for Java and/or Python.
 
@@ -566,8 +568,14 @@ def write_config_files(out_dir='.',
                 f.write('jvm_dll = %s\n' % repr(jvm_dll_file))
                 f.write('jvm_maxmem = None\n')
                 f.write('jvm_classpath = []\n')
-                f.write('jvm_properties = {}\n')
-                f.write('jvm_options = []\n')
+                if jvm_properties is None:
+                    f.write('jvm_properties = {}\n')
+                else:
+                    f.write('jvm_properties = ' + str(jvm_properties) + '\n')
+                if jvm_options is None:
+                    f.write('jvm_options = []\n')
+                else:
+                    f.write('jvm_options = [''' + jvm_options + ''']\n''')
             logger.info("jpy Python API configuration written to '%s'" % py_api_config_file)
         except Exception:
             logger.exception("Error while writing Python API configuration")


### PR DESCRIPTION
Allow jvm_properties and jvm_options to be passed to the method write_config_files method in jpyutil.py.